### PR TITLE
add an initial version of a shoreline roughness calculation

### DIFF
--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -2,6 +2,69 @@ import numpy as np
 from scipy import stats
 import matplotlib.pyplot as plt
 
+from . import mask
+
+
+def compute_shoreline_roughness(shore_mask, land_mask):
+    """Compute shoreline roughness.
+
+    Computes the shoreline roughness metric:
+
+    .. math::
+
+        L_{shore} / \sqrt{A_{land}}
+
+    given binary masks of the shoreline and land area.
+
+    Parameters
+    ----------
+    shore_mask : :obj:`~deltametrics.mask.ShorelineMask`, :obj:`ndarray`
+        Shoreline mask. Can be a :obj:`~deltametrics.mask.ShorelineMask` object,
+        or a binarized array.
+
+    land_mask : :obj:`~deltametrics.mask.LandMask`, :obj:`ndarray`
+        Land mask. Can be a :obj:`~deltametrics.mask.LandMask` object,
+        or a binarized array.
+
+    Returns
+    -------
+    roughness : :obj:`float`
+        Shoreline roughness, computed as described above.
+    """
+
+    if isinstance(shore_mask, mask.ShorelineMask):
+        _sm = shore_mask.mask
+    if isinstance(land_mask, mask.LandMask):
+        _lm = land_mask.mask
+
+    if np.sum(_sm) > 0:
+        # sort the shoreline mask into a shoreline "line"
+        _y, _x = np.argwhere(_sm).T
+        _closest = np.argmin(np.sqrt((_x-0)**2 + (_y-0)**2))
+        _xs = np.zeros(len(_x))
+        _ys = np.zeros(len(_y))
+        _xs[0] = _x[_closest]
+        _ys[0] = _y[_closest]
+        _hit = np.zeros(len(_x), dtype=np.bool)
+        _hit[_closest] = True
+        for i in range(len(_x)-1):
+            _xi = _xs[i]
+            _yi = _ys[i]
+            _dists = np.sqrt((_x[~_hit]-_xi)**2 + (_y[~_hit]-_yi)**2)
+            _whr = np.argmin(_dists)
+            _xs[i+1] = _x[~_hit][_whr]
+            _ys[i+1] = _y[~_hit][_whr]
+            __whr = np.argwhere(~_hit)
+            _hit[__whr[_whr]] = True
+
+        shore_len_pix = np.sum(np.sqrt((_xs[1:]-_xs[:-1])**2 +
+                                       (_ys[1:]-_ys[:-1])**2))
+        land_area_pix = np.sum(_lm)
+        rough = shore_len_pix / np.sqrt(land_area_pix)
+    else:
+        rough = np.nan
+    return rough
+
 
 def a_land_function(mask):
     """Compute a land-water function

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -26,6 +26,10 @@ def compute_shoreline_roughness(shore_mask, land_mask, **kwargs):
         Land mask. Can be a :obj:`~deltametrics.mask.LandMask` object,
         or a binarized array.
 
+    **kwargs
+        Keyword argument are passed to :obj:`compute_shoreline_length`
+        internally.
+
     Returns
     -------
     roughness : :obj:`float`
@@ -38,13 +42,13 @@ def compute_shoreline_roughness(shore_mask, land_mask, **kwargs):
         _lm = land_mask
 
     _ = kwargs.pop('return_line', None)  # trash this variable if passed
-    shorelength, shoreline = compute_shoreline_length(
-        shore_mask, return_line=True)
+    shorelength = compute_shoreline_length(
+        shore_mask, return_line=False, **kwargs)
 
     # compute the length of the shoreline and area of land
     shore_len_pix = shorelength
     land_area_pix = np.sum(_lm)
-    
+
     if (land_area_pix > 0):
         # compute roughness
         rough = shore_len_pix / np.sqrt(land_area_pix)
@@ -68,48 +72,116 @@ def compute_shoreline_length(shore_mask, origin=[0, 0], return_line=False):
     if not (np.sum(_sm) > 0):
         raise ValueError('No pixels in shoreline mask.')
 
+    if _sm.ndim == 3:
+        _sm = _sm.squeeze()
+
     # find where the mask is True (all x-y pairs along shore)
     _y, _x = np.argwhere(_sm).T
 
     # preallocate line arrays
-    line_xs = np.zeros(len(_x))
-    line_ys = np.zeros(len(_y))
+    line_xs_0 = np.zeros(len(_x),)
+    line_ys_0 = np.zeros(len(_y),)
 
     # determine a starting coordinate based on the proximity to the origin
     _closest = np.argmin(
         np.sqrt((_x - origin[0])**2 + (_y - origin[1])**2))
-    line_xs[0] = _x[_closest]
-    line_ys[0] = _y[_closest]
+    line_xs_0[0] = _x[_closest]
+    line_ys_0[0] = _y[_closest]
     
     # preallocate an array to track whether a point has been used
-    _hit = np.zeros(len(_x), dtype=np.bool)
-    _hit[_closest] = True
+    hit_pts = np.zeros(len(_x), dtype=np.bool)
+    hit_pts[_closest] = True
 
-    # loop through all of the other points and organize into a line
-    for i in range(len(_x)-1):
-        # compute distance from ith point to all other points
-        _xi, _yi = line_xs[i], line_ys[i]
-        _dists = np.sqrt((_x[~_hit]-_xi)**2 + (_y[~_hit]-_yi)**2)
+    # compute the distance to the next point
+    dists_pts = np.sqrt((_x[~hit_pts]-_x[_closest])**2 + (_y[~hit_pts]-_y[_closest])**2)
+    dist_next = np.min(dists_pts)
+    dist_max = np.sqrt(15)
+
+    # # loop through all of the other points and organize into a line
+    idx = 0
+    while (dist_next <= dist_max):
+        
+        idx += 1
 
         # find where the distance is minimized (i.e., next point)
-        _whr = np.argmin(_dists)
+        _whr = np.argmin(dists_pts)
 
         # fill the line array with that point
-        line_xs[i+1] = _x[~_hit][_whr]
-        line_ys[i+1] = _y[~_hit][_whr]
+        line_xs_0[idx] = _x[~hit_pts][_whr]
+        line_ys_0[idx] = _y[~hit_pts][_whr]
 
         # find that point in the hit list and update it
-        __whr = np.argwhere(~_hit)
-        _hit[__whr[_whr]] = True
+        __whr = np.argwhere(~hit_pts)
+        hit_pts[__whr[_whr]] = True
 
+        # compute distance from ith point to all other points
+        _xi, _yi = line_xs_0[idx], line_ys_0[idx]
+        dists_pts = np.sqrt((_x[~hit_pts]-_xi)**2 + (_y[~hit_pts]-_yi)**2)
+        if (not np.all(hit_pts)):
+            dist_next = np.min(dists_pts)
+        else:
+            dist_next = np.inf
+
+    # trim the list
+    line_xs_0 = np.copy(line_xs_0[:idx+1])
+    line_ys_0 = np.copy(line_ys_0[:idx+1])
+
+    #############################################
+    # return to the first point and iterate again
+    line_xs_1 = np.zeros(len(_x),)
+    line_ys_1 = np.zeros(len(_y),)
+
+    if (not np.all(hit_pts)):
+
+        # compute dists from the intial point
+        dists_pts = np.sqrt((_x[~hit_pts]-line_xs_0[0])**2 + (_y[~hit_pts]-line_ys_0[0])**2)
+        dist_next = np.min(dists_pts)
+
+        # loop through all of the other points and organize into a line
+        idx = -1
+        while (dist_next <= dist_max):
+            
+            idx += 1
+
+            # find where the distance is minimized (i.e., next point)
+            _whr = np.argmin(dists_pts)
+
+            # fill the line array with that point
+            line_xs_1[idx] = _x[~hit_pts][_whr]
+            line_ys_1[idx] = _y[~hit_pts][_whr]
+
+            # find that point in the hit list and update it
+            __whr = np.argwhere(~hit_pts)
+            hit_pts[__whr[_whr]] = True
+
+            # compute distance from ith point to all other points
+            _xi, _yi = line_xs_1[idx], line_ys_1[idx]
+            dists_pts = np.sqrt((_x[~hit_pts]-_xi)**2 + (_y[~hit_pts]-_yi)**2)
+            if (not np.all(hit_pts)):
+                dist_next = np.min(dists_pts)
+            else:
+                dist_next = np.inf
+
+        # trim the list
+        line_xs_1 = np.copy(line_xs_1[:idx+1])
+        line_ys_1 = np.copy(line_ys_1[:idx+1])
+    else:
+        line_xs_1 = np.array([])
+        line_ys_1 = np.array([])
+
+    # combine the lists
+    line_xs = np.hstack((np.flip(line_xs_1), line_xs_0))
+    line_ys = np.hstack((np.flip(line_ys_1), line_ys_0))
+
+    # combine the xs and ys
     line = np.column_stack((line_xs, line_ys))
-    length = np.sum(np.sqrt((line_xs[1:]-line_xs[:-1])**2 +
-                            (line_ys[1:]-line_ys[:-1])**2))
+    length = np.sum(np.sqrt((line_xs[1:]-line_xs[:-1])**2 + (line_ys[1:]-line_ys[:-1])**2))
 
     if return_line:
         return length, line
     else:
         return length
+
 
 def a_land_function(mask):
     """Compute a land-water function

--- a/docs/source/reference/plan/index.rst
+++ b/docs/source/reference/plan/index.rst
@@ -17,6 +17,8 @@ The functions are defined in ``deltametrics.plan``.
 .. autosummary:: 
 	:toctree: ../../_autosummary
 
+	compute_shoreline_roughness
+	compute_shoreline_length
 	a_land_function
 	compute_delta_radius
 	a_channel_function

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,42 @@
+import pytest
+
+import sys
+import os
+
+import numpy as np
+
+from deltametrics.sample_data.cube import rcm8
+
+from deltametrics import mask
+from deltametrics import plan
+
+
+class TestShorelineRoughness:
+
+    rcm8 = rcm8()
+    lm = mask.LandMask(rcm8['eta'][-1, :, :])
+    sm = mask.ShorelineMask(rcm8['eta'][-1, :, :])
+
+    def test_compute_shoreline_roughness_rcm8(self):
+        # test it with default options
+        rgh_0 = plan.compute_shoreline_roughness(self.sm, self.lm)
+        assert rgh_0 == pytest.approx(5.5882170024)
+
+        # test that it ignores return_line arg
+        rgh_1 = plan.compute_shoreline_roughness(self.sm, self.lm,
+                                                 return_line=False)
+        assert rgh_1 == rgh_0
+
+        # test that it is the same with opposite side origin
+        rgh_2 = plan.compute_shoreline_roughness(self.sm, self.lm,
+                                                 origin=[0, self.rcm8.shape[1]])
+        assert rgh_2 == rgh_0
+
+    def test_compute_shoreline_roughness_asarray(self):
+        pass
+
+
+class TestShorelineLength:
+
+    def test_compute_shoreline_length(self):
+        pass

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -11,32 +11,126 @@ from deltametrics import mask
 from deltametrics import plan
 
 
+simple_land = np.zeros((10, 10))
+simple_shore = np.zeros((10, 10))
+simple_land[:4, :] = 1
+simple_land[4, 2:7] = 1
+simple_shore_array = np.array([[3, 3, 4, 4, 4, 4, 4, 3, 3, 3],
+                               [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]).T
+simple_shore[simple_shore_array[:, 0], simple_shore_array[:, 1]] = 1
+
+
 class TestShorelineRoughness:
 
     rcm8 = rcm8()
     lm = mask.LandMask(rcm8['eta'][-1, :, :])
     sm = mask.ShorelineMask(rcm8['eta'][-1, :, :])
+    lm0 = mask.LandMask(rcm8['eta'][0, :, :])
+    sm0 = mask.ShorelineMask(rcm8['eta'][0, :, :])
 
-    def test_compute_shoreline_roughness_rcm8(self):
+    rcm8_expected = 3.815412785718
+
+    def test_simple_case(self):
+        simple_rgh = plan.compute_shoreline_roughness(simple_shore, simple_land)
+        exp_area = 45
+        exp_len = (7*1)+(2*1.41421356)
+        exp_rgh = exp_len / np.sqrt(exp_area)
+        assert simple_rgh == pytest.approx(exp_rgh)
+
+    def test_rcm8_defaults(self):
         # test it with default options
         rgh_0 = plan.compute_shoreline_roughness(self.sm, self.lm)
-        assert rgh_0 == pytest.approx(5.5882170024)
+        assert rgh_0 == pytest.approx(self.rcm8_expected)
 
+    def test_rcm8_ignore_return_line(self):
         # test that it ignores return_line arg
         rgh_1 = plan.compute_shoreline_roughness(self.sm, self.lm,
                                                  return_line=False)
-        assert rgh_1 == rgh_0
+        assert rgh_1 == pytest.approx(self.rcm8_expected)
 
+    def test_rcm8_defaults_opposite(self):
         # test that it is the same with opposite side origin
         rgh_2 = plan.compute_shoreline_roughness(self.sm, self.lm,
                                                  origin=[0, self.rcm8.shape[1]])
-        assert rgh_2 == rgh_0
+        assert rgh_2 == pytest.approx(self.rcm8_expected, abs=0.1)
+
+    def test_rcm8_fail_no_shoreline(self):
+        # check raises error 
+        with pytest.raises(ValueError, match=r'No pixels in shoreline mask.'):
+            plan.compute_shoreline_roughness(self.sm0, self.lm)
+
+    @pytest.mark.xfail(strict=True, reason='Landmask when no land is an array of '
+                                           'all 1, but should be an array of all 0.')
+    def test_rcm8_fail_no_land(self):
+        # check raises error 
+        with pytest.raises(ValueError, match=r'No pixels in land mask.'):
+            plan.compute_shoreline_roughness(self.sm, self.lm0)
 
     def test_compute_shoreline_roughness_asarray(self):
-        pass
+        # test it with default options
+        _smarr = np.copy(self.sm.mask)
+        _lmarr = np.copy(self.lm.mask)
+        assert isinstance(_smarr, np.ndarray)
+        assert isinstance(_lmarr, np.ndarray)
+        rgh_3 = plan.compute_shoreline_roughness(_smarr, _lmarr)
+        assert rgh_3 == pytest.approx(self.rcm8_expected)
 
 
 class TestShorelineLength:
 
-    def test_compute_shoreline_length(self):
-        pass
+    rcm8 = rcm8()
+    sm = mask.ShorelineMask(rcm8['eta'][-1, :, :])
+    sm0 = mask.ShorelineMask(rcm8['eta'][0, :, :])
+
+    rcm8_expected = 333.7995598385
+
+    def test_simple_case(self):
+        simple_len = plan.compute_shoreline_length(simple_shore)
+        exp_len = (7*1)+(2*1.41421356)
+        assert simple_len == pytest.approx(exp_len)
+
+    def test_simple_case_opposite(self):
+        simple_len = plan.compute_shoreline_length(simple_shore, origin=[10, 0])
+        exp_len = (7*1)+(2*1.41421356)
+        assert simple_len == pytest.approx(exp_len)
+
+    def test_simple_case_return_line(self):
+        simple_len, simple_line = plan.compute_shoreline_length(simple_shore, return_line=True)
+        exp_len = (7*1)+(2*1.41421356)
+        assert simple_len == pytest.approx(exp_len)
+        assert np.all(simple_line == np.fliplr(simple_shore_array))
+
+    def test_rcm8_defaults(self):
+        # test that it is the same with opposite side origin
+        len_0 = plan.compute_shoreline_length(self.sm)
+        assert len_0 == pytest.approx(self.rcm8_expected)
+
+    def test_rcm8_defaults_opposite(self):
+        # test that it is the same with opposite side origin
+        len_0, line_0 = plan.compute_shoreline_length(
+            self.sm, return_line=True)
+        _o = [self.rcm8.shape[2], 0]
+        len_1, line_1 = plan.compute_shoreline_length(
+            self.sm, origin=_o, return_line=True)
+        if False:
+            import matplotlib.pyplot as plt
+            fig, ax = plt.subplots(1, 2)
+            ax[0].imshow(self.sm.mask.squeeze())
+            ax[1].imshow(self.sm.mask.squeeze())
+            ax[0].plot(0, 0, 'ro')
+            ax[1].plot(_o[0], _o[1], 'bo')
+            ax[0].plot(line_0[:,0], line_0[:,1], 'r-')
+            ax[1].plot(line_1[:,0], line_1[:,1], 'b-')
+            plt.show(block=False)
+
+            fig, ax = plt.subplots()
+            ax.plot(np.cumsum(np.sqrt((line_0[1:,0]-line_0[:-1,0])**2 + (line_0[1:,1]-line_0[:-1,1])**2)))
+            ax.plot(np.cumsum(np.sqrt((line_1[1:,0]-line_1[:-1,0])**2 + (line_1[1:,1]-line_1[:-1,1])**2)))
+            plt.show()
+            breakpoint()
+        assert len_1 == pytest.approx(self.rcm8_expected, abs=5.0)
+
+    # def test_rcm8_fail_no_shoreline(self):
+    #     # check raises error 
+    #     with pytest.raises(ValueError, match=r'No pixels in shoreline mask.'):
+    #         plan.compute_shoreline_length(self.sm0)


### PR DESCRIPTION
Add a shoreline roughness and shoreline length calculation.

Shoreline poly-line is determined by a pretty hacky algorithm, so I'm going to open an issue to potentially improve it in the future.

Todo:
- [x] tests
- [x] documentation
- [ ] shift the sorting algorithm out to a util to be potentially used by other functions?