### PR TITLE
Channel mobility metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,10 +48,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up Python 3.x
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/deltametrics/__init__.py
+++ b/deltametrics/__init__.py
@@ -1,6 +1,7 @@
 from . import cube
 from . import plan
 from . import mask
+from . import mobility
 from . import section
 from . import strat
 from . import utils

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -346,8 +346,10 @@ def calc_chan_abandonment(chmap, basevalues, time_window):
     Returns
     -------
     PwetA : ndarray
-        Vector of number of pixels that are abandonded for a given time lag,
-        averaged over the time window under study
+        A 2-D array of the abandoned fraction of the channel over the window of
+        time. It is of shape len(basevalues) x time_window so each row
+        represents the fraction of the channel that has been abandonded, and
+        the columns are associated with each time lag.
 
     """
     # sanitize the inputs first
@@ -355,7 +357,7 @@ def calc_chan_abandonment(chmap, basevalues, time_window):
                                                            basevalues,
                                                            time_window)
     # initialize values
-    PwetA = np.zeros((time_window, 1))
+    PwetA = np.zeros((len(basevalues), time_window))
     chA_base = np.zeros_like(chmap[0, :, :])
     chA_step = np.zeros_like(chmap[0, :, :])
 
@@ -366,20 +368,14 @@ def calc_chan_abandonment(chmap, basevalues, time_window):
         chA_base = chmap[Nbase, :, :]
         # get total number of channel pixels in that map
         baseA = np.sum(chA_base)
-
         # loop through the other maps to be compared against the base map
         for Nstep in range(1, time_window):
             # get the incremental map
             chA_step = chmap[Nbase+Nstep, :, :]
-            # get the number of pixels that are no longer channelized (aka
-            # abandonded)
+            # get the number of pixels that were abandonded
             stepA = len(np.where(chA_base.flatten() > chA_step.flatten())[0])
-            # store this number in the vector PwetA for each incremental map
-            PwetA[Nstep] = PwetA[Nstep] + (1-stepA/baseA)
-
-    # normalize PwetA by the number of incremental steps used to generate each
-    # value
-    PwetA = PwetA/time_window
+            # store this number in the PwetA array for each transient map
+            PwetA[i, Nstep] = stepA/baseA
 
     return PwetA
 

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -80,7 +80,7 @@ def check_inputs(chmap, basevalues, time_window, landmap=None):
         if len(landmap.shape) != 3:
             try:
                 tmp_landmap = np.empty(chmap.shape)
-                for i in range(0,tmp_landmap.shape[0]):
+                for i in range(0, tmp_landmap.shape[0]):
                     tmp_landmap[i, :, :] = landmap
                 landmap = tmp_landmap
             except Exception:

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -1,0 +1,375 @@
+"""Functions for channel mobility metrics.
+
+Current available mobility metrics include:
+    - Dry fraction decay from Cazanacli et al 2002
+    - Planform overlap from Wickert et al 2013
+    - Reworking index from Wickert et al 2013
+    - Channel abandonment from Liang et al 2016
+
+Also included are functions to fit curves to the output from the mobility
+functions, allowing for decay constants and timescales to be quantified.
+"""
+
+import numpy as np
+from deltametrics import mask
+import xarray as xr
+from scipy.optimize import curve_fit
+
+
+def check_inputs(chmap, basevalues, time_window, landmap=None):
+    """
+    Check the input variable values.
+
+    Ensures compatibility with mobility functions. Tries to convert from some
+    potential input types (xarray data arrays, deltametrics masks) if possible.
+
+    Parameters
+    ----------
+    chmap : ndarray
+        A t-x-y shaped array with binary channel maps.
+
+    basevalues : list
+        List of t indices to use as the base channel maps.
+
+    time_window : int
+        Number of time slices (t indices) to use as the time lag
+
+    landmap : ndarray, optional
+        A t-x-y shaped array with binary land maps.
+
+    """
+    # check binary map types - pull out ndarray from mask or xarray if needed
+    if isinstance(chmap, np.ndarray) is True:
+        pass
+    elif isinstance(chmap, mask.BaseMask) is True:
+        chmap = chmap.mask
+    elif isinstance(chmap, xr.core.dataarray.DataArray) is True:
+        chmap = chmap.values
+    else:
+        raise TypeError('chmap data type not understood.')
+
+    if landmap is not None:
+        if isinstance(landmap, np.ndarray) is True:
+            pass
+        elif isinstance(landmap, mask.BaseMask) is True:
+            landmap = landmap.mask
+        elif isinstance(landmap, xr.core.dataarray.DataArray) is True:
+            landmap = landmap.values
+        else:
+            raise TypeError('landmap data type not understood.')
+
+    # check basevalues and time_window types
+    if isinstance(basevalues, list) is False:
+        try:
+            basevalues = list(basevalues)
+        except Exception:
+            raise TypeError('basevalues was not a list or list()-able obj.')
+
+    if isinstance(time_window, int) is False:
+        try:
+            time_window = int(time_window)
+        except Exception:
+            raise TypeError('time_window was not an int or int()-able obj.')
+
+    # check map shapes (expect 3D t-x-y arrays of same size)
+    if len(chmap.shape) != 3:
+        raise ValueError('Shape of chmap not 3D (expect t-x-y).')
+    if landmap is not None:
+        if len(landmap.shape) != 3:
+            raise ValueError('Shape of landmap not 3D (expect t-x-y)')
+
+        if np.shape(chmap) != np.shape(landmap):
+            raise ValueError('Shapes of chmap and landmap do not match.')
+
+    # check that the combined basemap + timewindow does not exceed max t-index
+    Kmax = np.max(basevalues) + time_window
+    if Kmax > chmap.shape[0]:
+        raise ValueError('Largest basevalue + time_window exceeds max time.')
+
+    # return the sanitized variables
+    return chmap, landmap, basevalues, time_window
+
+
+def calc_chan_decay(chmap, landmap, basevalues, time_window):
+    """
+    Calculate channel decay (reduction in dry fraction).
+
+    Uses a method similar to that in Cazanacli et al 2002 to measure the
+    dry fraction of a delta over time. This requires providing an input channel
+    map, an input land map, choosing a set of base maps to use, and a time
+    lag/time window over which to do the analysis.
+
+    Parameters
+    ----------
+    chmap : ndarray
+        A t-x-y shaped array with binary channel maps.
+
+    landmap : ndarray
+        A t-x-y shaped array with binary land maps.
+
+    basevalues : list
+        List of t indices to use as the base channel maps.
+
+    time_window : int
+        Number of time slices (t indices) to use as the time lag
+
+    Returns
+    -------
+    dryfrac : ndarray
+        len(basevalues) x time_window 2-D array with each row representing
+        the dry fraction (aka number of pixels not visited by a channel) in
+        reference to a given base value at a certain time lag (column)
+
+    """
+    # sanitize the inputs first
+    chmap, landmap, basevalues, time_window = check_inputs(chmap,
+                                                           basevalues,
+                                                           time_window,
+                                                           landmap)
+
+    # initialize dry fraction array
+    dryfrac = np.zeros((len(basevalues), time_window))
+
+    # loop through basevalues
+    for i in range(0, len(basevalues)):
+        # pull the corresponding time index for the base value
+        Nbase = basevalues[i]
+        # first get the dry map (non-channelized locations)
+        base_dry = np.abs(chmap[Nbase, :, :] - landmap[Nbase, :, :])
+
+        # define base landmap
+        base_map = landmap[Nbase, :, :]
+
+        # set first dry fraction at t=0
+        dryfrac[i, 0] = np.sum(base_dry) / np.sum(base_map)
+
+        # loop through the other maps to see how the dry area declines
+        for Nstep in range(1, time_window):
+            # get the incremental map
+            chA_step = chmap[Nbase+Nstep, :, :]
+            # subtract incremental map from dry map to get the new dry fraction
+            base_dry -= chA_step
+            # just want binary (1 = never channlized, 0 = channel visited)
+            base_dry[base_dry < 0] = 0  # no need to have negative values
+            # store remaining dry fraction
+            dryfrac[i, Nstep] = np.sum(base_dry) / np.sum(base_map)
+
+    return dryfrac
+
+
+def calc_planform_overlap(chmap, landmap, basevalues, time_window):
+    """
+    Calculate channel planform overlap.
+
+    Uses a method similar to that described in Wickert et al 2013 to measure
+    the loss of channel system overlap with previous channel patterns. This
+    requires an input channel map, land map, as well as defining the base maps
+    to use and the time window over which you want to look.
+
+    Parameters
+    ----------
+    chmap : ndarray
+        A t-x-y shaped array with binary channel maps
+
+    landmap : ndarray
+        A t-x-y shaped array with binary land maps
+
+    basevalues : list
+        A list of values (t indices) to use for the base channel maps
+
+    time_window : int
+        Number of time slices (t values) to use for the transient maps
+
+    Returns
+    -------
+    Ophi : ndarray
+        A 2-D array of the normalized overlap values, array is of shape
+        len(basevalues) x time_window so each row in the array represents
+        the overlap values associated with a given base value and the
+        columns are associated with each time lag.
+
+    """
+    # sanitize the inputs first
+    chmap, landmap, basevalues, time_window = check_inputs(chmap,
+                                                           basevalues,
+                                                           time_window,
+                                                           landmap)
+
+    # initialize D, phi and Ophi
+    D = np.zeros((len(basevalues), time_window))
+    phi = np.zeros_like(D)
+    Ophi = np.zeros_like(D)
+
+    # loop through the base maps
+    for j in range(0, len(basevalues)):
+        # define variables associated with the base map
+        fdrybase = 1 - (np.sum(chmap[basevalues[j], :, :]) /
+                        np.sum(landmap[basevalues[j], :, :]))
+        fwetbase = np.sum(chmap[basevalues[j], :, :]) / \
+            np.sum(landmap[basevalues[j], :, :])
+        # transient maps compared over the fluvial surface present in base map
+        mask_map = landmap[basevalues[j], :, :]
+
+        # loop through the transient maps associated with this base map
+        for i in range(0, time_window):
+            D[j, i] = np.sum(np.abs(chmap[basevalues[j], :, :]*mask_map -
+                                    chmap[basevalues[j]+i, :, :]*mask_map))
+            fdrystep = 1 - (np.sum(chmap[basevalues[j]+i, :, :]*mask_map) /
+                            np.sum(mask_map))
+            fwetstep = np.sum(chmap[basevalues[j]+i, :, :]*mask_map) / \
+                np.sum(mask_map)
+            phi[j, i] = fwetbase*fdrystep + fdrybase*fwetstep
+            # for Ophi use a standard area in denominator, we use base area
+            Ophi[j, i] = 1 - D[j, i]/(np.sum(mask_map)*phi[j, i])
+
+    # just return the Ophi
+    return Ophi
+
+
+def calc_reworking_fraction(chmap, landmap, basevalues, time_window):
+    """
+    Calculate the reworking fraction.
+
+    Uses a method similar to that described in Wickert et al 2013 to measure
+    the reworking of the fluvial surface with time. This requires an input
+    channel map, land map, as well as defining the base maps to use and the
+    time window over which you want to look.
+
+    Parameters
+    ----------
+    chmap : ndarray
+        A t-x-y shaped array with binary channel maps
+
+    landmap : ndarray
+        A t-x-y shaped array with binary land maps
+
+    basevalues : list
+        A list of values (t indices) to use for the base channel maps
+
+    time_window : int
+        Number of time slices (t values) to use for the transient maps
+
+    Returns
+    -------
+    fr : ndarray
+        A 2-D array of the reworked fraction values, array is of shape
+        len(basevalues) x time_window so each row in the array represents
+        the overlap values associated with a given base value and the
+        columns are associated with each time lag.
+
+    """
+    # sanitize the inputs first
+    chmap, landmap, basevalues, time_window = check_inputs(chmap,
+                                                           basevalues,
+                                                           time_window,
+                                                           landmap)
+
+    # initialize unreworked pixels (Nbt) and reworked fraction (fr)
+    Nbt = np.zeros((len(basevalues), time_window))
+    fr = np.zeros_like(Nbt)
+
+    # loop through the base maps
+    for j in range(0, len(basevalues)):
+        # define variables associated with the base map
+        base = basevalues[j]
+        # fluvial surface is considered to be the one present in base map
+        basemask = landmap[base, :, :]
+        notland = len(np.where(basemask == 0)[0])  # number of not-land pixels
+        basechannels = chmap[base, :, :]
+        fbase = basemask - basechannels
+        fdrybase = np.sum(fbase) / np.sum(basemask)
+
+        # initialize channelmap series through time (kb) using initial chmap
+        kb = np.copy(basechannels)
+
+        # loop through the transient maps associated with this base map
+        for i in range(0, time_window):
+            # if i == 0 no reworking has happened yet
+            if i == 0:
+                Nbt[j, i] = fdrybase * np.sum(basemask)
+                fr[j, i] = 0
+            else:
+                # otherwise situation is different
+
+                # transient channel map withint base fluvial surface
+                tmap = chmap[base+i, :, :]*basemask
+
+                # add to kb
+                kb += tmap
+
+                # unreworked pixels are those channels have not visited
+                # get this by finding all 0s left in kb and subtracting
+                # the number of non-land pixels from base fluvial surface
+                unvisited = len(np.where(kb == 0)[0])
+                Nbt[j, i] = unvisited - notland
+                fr[j, i] = 1 - (Nbt[j, i]/(np.sum(basemask)*fdrybase))
+
+    # just return the reworked fraction
+    return fr
+
+
+def calc_chan_abandonment(chmap, basevalues, time_window):
+    """
+    Calculate channel abandonment.
+
+    Measure the number of channelized pixels that are no longer channelized as
+    a signature of channel mobility based on method in Liang et al 2016. This
+    requires providing an input channel map, and setting parameters for the
+    min/max values to compare to, and the time window over which the evaluation
+    can be done.
+
+    Parameters
+    ----------
+    chmap : ndarray
+        A t-x-y shaped array with binary channel maps
+
+    basevalues : list
+        A list of values (t indices) to use for the base channel maps
+
+    time_window : int
+        Number of time slices (t values) to use for the transient maps
+
+    Returns
+    -------
+    PwetA : ndarray
+        Vector of number of pixels that are abandonded for a given time lag,
+        averaged over the time window under study
+
+    """
+    # sanitize the inputs first
+    chmap, landmap, basevalues, time_window = check_inputs(chmap,
+                                                           basevalues,
+                                                           time_window)
+    # initialize values
+    PwetA = np.zeros((time_window, 1))
+    chA_base = np.zeros_like(chmap[0, :, :])
+    chA_step = np.zeros_like(chmap[0, :, :])
+
+    # loop through the basevalues
+    for i in range(0, len(basevalues)):
+        # first get the 'base' channel map that is being compared to
+        Nbase = basevalues[i]
+        chA_base = chmap[Nbase, :, :]
+        # get total number of channel pixels in that map
+        baseA = np.sum(chA_base)
+
+        # loop through the other maps to be compared against the base map
+        for Nstep in range(1, time_window):
+            # get the incremental map
+            chA_step = chmap[Nbase+Nstep, :, :]
+            # get the number of pixels that are no longer channelized (aka
+            # abandonded)
+            stepA = len(np.where(chA_base.flatten() > chA_step.flatten())[0])
+            # store this number in the vector PwetA for each incremental map
+            PwetA[Nstep] = PwetA[Nstep] + (1-stepA/baseA)
+
+    # normalize PwetA by the number of incremental steps used to generate each
+    # value
+    PwetA = PwetA/time_window
+
+    return PwetA
+
+
+def mobility_curve_fit(mdata, fit='harmonic'):
+    """Calculate curve fit for channel mobility data."""
+    raise NotImplementedError

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -50,6 +50,11 @@ def check_inputs(chmap, basevalues, time_window, landmap=None):
     else:
         raise TypeError('chmap data type not understood.')
 
+    if ((chmap == 0) | (chmap == 1)).all():
+        pass
+    else:
+        raise ValueError('chmap was not binary')
+
     if landmap is not None:
         if isinstance(landmap, np.ndarray) is True:
             pass
@@ -59,6 +64,10 @@ def check_inputs(chmap, basevalues, time_window, landmap=None):
             landmap = landmap.values
         else:
             raise TypeError('landmap data type not understood.')
+        if ((landmap==0) | (landmap==1)).all():
+            pass
+        else:
+            raise ValueError('landmap was not binary')
 
     # check basevalues and time_window types
     if isinstance(basevalues, list) is False:

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -13,7 +13,6 @@ functions, allowing for decay constants and timescales to be quantified.
 import numpy as np
 from deltametrics import mask
 import xarray as xr
-from scipy.optimize import curve_fit
 
 
 def check_inputs(chmap, basevalues, time_window, landmap=None):
@@ -64,7 +63,7 @@ def check_inputs(chmap, basevalues, time_window, landmap=None):
             landmap = landmap.values
         else:
             raise TypeError('landmap data type not understood.')
-        if ((landmap==0) | (landmap==1)).all():
+        if ((landmap == 0) | (landmap == 1)).all():
             pass
         else:
             raise ValueError('landmap was not binary')
@@ -108,7 +107,7 @@ def check_inputs(chmap, basevalues, time_window, landmap=None):
     return chmap, landmap, basevalues, time_window
 
 
-def calc_chan_decay(chmap, landmap, basevalues, time_window):
+def calculate_channel_decay(chmap, landmap, basevalues, time_window):
     """
     Calculate channel decay (reduction in dry fraction).
 
@@ -177,7 +176,7 @@ def calc_chan_decay(chmap, landmap, basevalues, time_window):
     return dryfrac
 
 
-def calc_planform_overlap(chmap, landmap, basevalues, time_window):
+def calculate_planform_overlap(chmap, landmap, basevalues, time_window):
     """
     Calculate channel planform overlap.
 
@@ -247,7 +246,7 @@ def calc_planform_overlap(chmap, landmap, basevalues, time_window):
     return Ophi
 
 
-def calc_reworking_fraction(chmap, landmap, basevalues, time_window):
+def calculate_reworking_fraction(chmap, landmap, basevalues, time_window):
     """
     Calculate the reworking fraction.
 
@@ -331,7 +330,7 @@ def calc_reworking_fraction(chmap, landmap, basevalues, time_window):
     return fr
 
 
-def calc_chan_abandonment(chmap, basevalues, time_window):
+def calculate_channel_abandonment(chmap, basevalues, time_window):
     """
     Calculate channel abandonment.
 
@@ -387,67 +386,3 @@ def calc_chan_abandonment(chmap, basevalues, time_window):
             PwetA[i, Nstep] = stepA/baseA
 
     return PwetA
-
-
-def mobility_curve_fit(mdata, fit='harmonic'):
-    """
-    Calculate curve fit for channel mobility data.
-
-    Given some mobility data output from one of the mobility metrics, fit a
-    curve to the average of that data. Several functional forms are available
-    for the fitting: exponential, harmonic, and linear functions.
-
-    Parameters
-    ----------
-    mdata : ndarray
-        Mobility data, either already averaged or a 2D array of of shape
-        len(basevalues) x time_window. Any output from one of the mobility
-        functions is acceptable.
-
-    fit : str, optional (default is 'harmonic')
-        A string specifying the type of function to be fit. Options are as
-        follows:
-            - 'exponential' : (a - b) * np.exp(-c * x) + b
-            - 'harmonic' : a / (1 + b * x)
-            - 'linear' : a * x + b
-
-    Returns
-    -------
-    yfit : ndarray
-        y-values corresponding to the fitted function.
-
-    pcov : ndarray
-        Covariance associated with the fitted function parameters.
-
-    perror : ndarray
-        One standard deviation error for the parameters (from pcov)
-
-    """
-    avail_fits = ['exponential', 'harmonic', 'linear']
-    if fit not in avail_fits:
-        raise ValueError('Fit specified is not valid.')
-
-    # average the mobility data if needed
-    if len(mdata.shape) == 2:
-        mdata = np.mean(mdata, axis=0)
-
-    # define x data
-    xdata = np.array(range(0, len(mdata)))
-
-    # do fit
-    if fit == 'harmonic':
-        func_harmonic = lambda x, a, b: a / (1 + b * x)
-        popt, pcov = curve_fit(func_harmonic, xdata, mdata)
-        yfit = func_harmonic(xdata, *popt)
-    elif fit == 'exponential':
-        func_exponential = lambda x, a, b, c: (a - b) * np.exp(-c * x) + b
-        popt, pcov = curve_fit(func_exponential, xdata, mdata)
-        yfit = func_exponential(xdata, *popt)
-    elif fit == 'linear':
-        func_linear = lambda x, a, b: a * x + b
-        popt, pcov = curve_fit(func_linear, xdata, mdata)
-        yfit = func_linear(xdata, *popt)
-
-    perror = np.sqrt(np.diag(pcov))
-
-    return yfit, pcov, perror

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -2,7 +2,7 @@
 User Guide
 **********
 
-This documentation provides a 
+This documentation provides a
 
 
 
@@ -34,7 +34,7 @@ Setting up your coding environment
 All of the documentation in this package assumes that you have imported the DeltaMetrics package as ``dm``:
 
 .. doctest::
-    
+
     >>> import deltametrics as dm
 
 Additionally, we frequently rely on the `numpy` package, and `matplotlib`. We will assume you have imported these packages by their common shorthand as well; if we import other packages, or other modules from `matplotlib`, these imports will be declared!
@@ -58,7 +58,7 @@ DeltaMetrics centers around the use of “Cubes” in DeltaMetrics language are 
 
 Creating the ``rcm8cube`` connects to a dataset, but does not read any of the data into memory, allowing for efficient computation on large datasets. The type of the ``rcm8cube`` is ``DataCube``.
 
-Inspect which variables are available in the ``rcm8cube``. 
+Inspect which variables are available in the ``rcm8cube``.
 
 .. doctest::
 
@@ -97,7 +97,7 @@ Let’s examine the timeseries of bed elevations by taking slices out of the ``'
 
 .. plot:: guides/userguide_bed_timeseries.py
 
-.. note:: 
+.. note::
 
     The 0th dimension of the cube is the *time* dimension, and the 1st and 2nd dimensions are the `y` and `x` dimensions of the model domain, respectively. The `x` dimension is the *cross-channel* dimension, Implementations using non-standard data should permute datasets to match this convention.
 
@@ -144,7 +144,7 @@ Manipulating Section data
 We are often interested in not only the spatiotemporal changes in the planform of the delta, but we want to know what is preserved in the subsurface.
 In DeltaMetrics, we refer to this preserved history as the "stratigraphy", and we provide a number of convenient routines for computing stratigraphy and analyzing the deposits.
 
-Importantly, the stratigraphy (or i.e., which voxels are preserved) is not computed by default when a Cube instance is created. 
+Importantly, the stratigraphy (or i.e., which voxels are preserved) is not computed by default when a Cube instance is created.
 We must directly tell the Cube instance to compute stratigraphy by specifying which variable contains the bed elevation history, because this history dictates preservation.
 
 Mainly, the API works by registering a section of a specified type, and
@@ -157,7 +157,7 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
     >>> rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
 
-which creates a section across a constant y-value ``==10``. 
+which creates a section across a constant y-value ``==10``.
 The path of any `Section` in the ``x-y`` plane can always be accessed via the ``.trace`` attribute.
 We can plot the trace on top the the final bed elevation to see where the section will be located.
 
@@ -225,7 +225,7 @@ We have implemented support for rapid stratigraphy computation for visualization
 These quick stratigraphy computations create a mesh of preserved elevations and fill this matrix with values sliced out of the ``t-x-y`` data.
 
 Notably, the full "boxy" stratigraphy computation is also quite fast.
-More on that below. 
+More on that below.
 Compute the quick stratigraphy as:
 
 .. doctest::
@@ -292,9 +292,9 @@ The following are currently implemented.
     >>> _strike = dm.section.StrikeSection(rcm8cube, y=18)
     >>> _path = dm.section.PathSection(rcm8cube, path=np.column_stack((np.linspace(50, 150, num=4000, dtype=np.int),
     ...                                                                np.linspace(10, 90, num=4000, dtype=np.int))))
-    
 
-The `Section` classes all inherit from the same ``BaseSection`` class, which means they mostly have the same options available to them, and have a common API. 
+
+The `Section` classes all inherit from the same ``BaseSection`` class, which means they mostly have the same options available to them, and have a common API.
 Each has unique instantiation arguments, though, which must be properly specified.
 
 .. doctest::
@@ -321,7 +321,7 @@ Computing and Manipulating Stratigraphy
 1) Does not consider volume of sediment filled by preserved-time indicies, 2) cannot be sliced by planform, 3) irregularity does not lend well to computation and other uses (hydrological studies).
 
 So, we want to be able to create what I refer to as "boxy" stratigraphy.
-This has been done in the past by "placing" values from, e.g., ``strata_sand_frac`` into stratigraphy. 
+This has been done in the past by "placing" values from, e.g., ``strata_sand_frac`` into stratigraphy.
 This requires full computation for any variable you want to examine though.
 Here, we use a method that computes boxy stratigraphy only once, then synthesizes the volume from
 the precomputed sparse indicies.
@@ -331,7 +331,7 @@ Here’s a simple example to demonstrate how we place data into the stratigraphy
 .. doctest::
 
     >>> ets = rcm8cube['eta'][:, 25, 120]  # a "real" slice of the model
-    
+
     >>> fig, ax = plt.subplots(figsize=(8, 4))
     >>> dm.plot.show_one_dimensional_trajectory_to_strata(ets, ax=ax, dz=0.25)
     >>> plt.show() #doctest: +SKIP
@@ -423,7 +423,7 @@ speed up computations if an array is being accessed over and over.
 
     fs = sc8cube.export_frozen_variable('strata_sand_frac')
     fe = sc8cube.Z  # exported volume does not have coordinate information!
-    
+
     fig, ax = plt.subplots(figsize=(10, 2))
     pcm = ax.pcolormesh(np.tile(np.arange(fs.shape[2]), (fs.shape[0], 1)),
        fe[:,10,:], fs[:,10,:], shading='auto',
@@ -468,8 +468,8 @@ methods to create new “variables” in the data cube which hold the binary
 values of the masks.
 
 Currently implemented `Masks`:
-  * ChannelMask 
-  * EdgeMask 
+  * ChannelMask
+  * EdgeMask
   * LandMask
   * ShorelineMask
   * WetMask
@@ -479,7 +479,7 @@ Currently implemented `Masks`:
 
     >>> # use a new cube, code is currently locked to sea_level==0
     >>> maskcube = dm.sample_data.cube.rcm8()
-    
+
     >>> # create the masks from variables in the cube
     >>> land_mask = dm.mask.LandMask(maskcube['eta'][-1, :, :])
     >>> wet_mask = dm.mask.WetMask(maskcube['eta'][-1, :, :])
@@ -497,7 +497,7 @@ Currently implemented `Masks`:
 
     >>> ax0.imshow(maskcube['eta'][-1, :, :]) #doctest: +SKIP
     >>> for i, m in enumerate([land_mask, wet_mask, channel_mask, centerline_mask, edge_mask, shore_mask]):
-    ...     axs[i].imshow(m.mask, cmap='gray') #doctest: +SKIP
+    ...     axs[i].imshow(m.mask[-1, :, :], cmap='gray') #doctest: +SKIP
     ...     axs[i].set_title(m.mask_type) #doctest: +SKIP
     >>> plt.show() #doctest: +SKIP
 

--- a/docs/source/pyplots/guides/userguide_masks_all_demo.py
+++ b/docs/source/pyplots/guides/userguide_masks_all_demo.py
@@ -18,5 +18,5 @@ ax0.imshow(rcm8cube['eta'][-1, :, :])
 
 for i, m in enumerate([land_mask, wet_mask, channel_mask,
                        centerline_mask, edge_mask, shore_mask]):
-    axs[i].imshow(m.mask, cmap='gray')
+    axs[i].imshow(m.mask[-1, :, :], cmap='gray')
     axs[i].set_title(m.mask_type)

--- a/docs/source/reference/index.rst
+++ b/docs/source/reference/index.rst
@@ -14,6 +14,7 @@ methods.
    cube/index
    plan/index
    mask/index
+   mobility/index
    section/index
    strat/index
    io/index

--- a/docs/source/reference/mask/index.rst
+++ b/docs/source/reference/mask/index.rst
@@ -7,7 +7,13 @@ Masking operations
 The package makes available routines for masking out planview attributes of
 the delta.
 
-This class is defined in ``deltametrics.mask``. 
+This class is defined in ``deltametrics.mask``.
+
+.. note::
+
+   When `Mask` objects are instantiated with single time-slice x-y planform
+   data (i.e., `L x W` data), the returned mask is expanded along the first
+   dimension to return an object with dimensions `1 x L x W`. This ensures that all `Mask` objects will have the same number of dimensions, but may lead to confusion if writing your own functions. 
 
 
 Mask classes
@@ -15,7 +21,7 @@ Mask classes
 
 .. currentmodule:: deltametrics.mask
 
-.. autosummary:: 
+.. autosummary::
 	:toctree: ../../_autosummary
 
 	BaseMask

--- a/docs/source/reference/mobility/index.rst
+++ b/docs/source/reference/mobility/index.rst
@@ -1,0 +1,30 @@
+.. api.mobile:
+
+***********************************
+Channel Mobility Functions
+***********************************
+
+This set of functions is for computing channel mobility metrics.
+Inputs to these functions are some sort of binary channel masks, and maps
+defining the fluvial surface (land area) over which the metrics should be
+computed. Functionality for fitting linear, harmonic, and exponential curves
+to the results of these functions is provided as well.
+
+
+The functions are defined in ``deltametrics.mobility``.
+
+
+.. mobility functions
+.. ===================
+
+.. currentmodule:: deltametrics.mobility
+
+.. autosummary::
+	:toctree: ../../_autosummary
+
+  check_inputs
+	calc_chan_decay
+	calc_planform_overlap
+	calc_reworking_fraction
+	calc_chan_abandonment
+	mobility_curve_fit

--- a/docs/source/reference/mobility/index.rst
+++ b/docs/source/reference/mobility/index.rst
@@ -20,11 +20,11 @@ The functions are defined in ``deltametrics.mobility``.
 .. currentmodule:: deltametrics.mobility
 
 .. autosummary::
-	:toctree: ../../_autosummary
+  :toctree: ../../_autosummary
 
   check_inputs
-	calc_chan_decay
-	calc_planform_overlap
-	calc_reworking_fraction
-	calc_chan_abandonment
-	mobility_curve_fit
+  calc_chan_decay
+  calc_planform_overlap
+  calc_reworking_fraction
+  calc_chan_abandonment
+  mobility_curve_fit

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ netCDF4
 pyyaml
 Shapely
 scikit-image
+xarray

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -75,6 +75,13 @@ class TestShorelineMask:
         with pytest.raises(TypeError):
             shoremask = mask.ShorelineMask('invalid')
 
+    def test_3d(self):
+        """Test with multiple time slices."""
+        # define the mask
+        shoremask = mask.ShorelineMask(rcm8cube['eta'][30:33, :, :])
+        # assert the shape
+        assert np.shape(shoremask.mask) == (3, 120, 240)
+
 
 class TestLandMask:
     """Tests associated with the mask.LandMask class."""
@@ -163,6 +170,13 @@ class TestLandMask:
         assert hasattr(landmask, 'shore_image') is True
         assert np.array_equal(landmask.mask,
                               landmask.mask.astype(bool)) is True
+
+    def test_3d(self):
+        """Test with multiple time slices."""
+        # define the mask
+        landmask = mask.LandMask(rcm8cube['eta'][30:33, :, :])
+        # assert the shape
+        assert np.shape(landmask.mask) == (3, 120, 240)
 
 
 class TestWetMask:
@@ -258,6 +272,13 @@ class TestWetMask:
         wetmask = mask.WetMask(rcm8cube['eta'][0, :, :], landmask=landmask)
         # assert - expect all values to be 0s
         assert np.all(wetmask.mask == 0)
+
+    def test_3d(self):
+        """Test with multiple time slices."""
+        # define the mask
+        wetmask = mask.WetMask(rcm8cube['eta'][30:33, :, :])
+        # assert the shape
+        assert np.shape(wetmask.mask) == (3, 120, 240)
 
 
 class TestChannelMask:
@@ -422,6 +443,14 @@ class TestChannelMask:
             channelmask = mask.ChannelMask('bad_velocity',
                                            rcm8cube['eta'][-1, :, :])
 
+    def test_3d(self):
+        """Test with multiple time slices."""
+        # define the mask
+        channelmask = mask.ChannelMask(rcm8cube['velocity'][30:33, :, :],
+                                       rcm8cube['eta'][30:33, :, :])
+        # assert the shape
+        assert np.shape(channelmask.mask) == (3, 120, 240)
+
 
 class TestEdgeMask:
     """Tests associated with the mask.EdgeMask class."""
@@ -564,6 +593,13 @@ class TestEdgeMask:
         # assert - expect all values to be 0s
         assert np.all(edgemask.mask == 0)
 
+    def test_3d(self):
+        """Test with multiple time slices."""
+        # define the mask
+        edgemask = mask.EdgeMask(rcm8cube['eta'][30:33, :, :])
+        # assert the shape
+        assert np.shape(edgemask.mask) == (3, 120, 240)
+
 
 class TestCenterlineMask:
     """Tests associated with the mask.CenterlineMask class."""
@@ -625,6 +661,15 @@ class TestCenterlineMask:
         centerlinemask = mask.CenterlineMask(channelmask)
         # assert - expect all values to be 0s
         assert np.all(centerlinemask.mask == 0)
+
+    def test_3d(self):
+        """Test with multiple time slices."""
+        # define the mask
+        channelmask = mask.ChannelMask(rcm8cube['velocity'][30:33, :, :],
+                                       rcm8cube['eta'][30:33, :, :])
+        centerlinemask = mask.CenterlineMask(channelmask)
+        # assert the shape
+        assert np.shape(centerlinemask.mask) == (3, 120, 240)
 
     @pytest.mark.xfail()
     def test_rivamapDefaults(self):

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -57,6 +57,25 @@ def test_check_input_nolandmask():
     assert isinstance(time_window, int) is True
 
 
+def test_check_input_notbinary_chmap():
+    """Test that nonbinary channel map raises error."""
+    ch_nonbin = np.zeros((3, 3, 3))
+    ch_nonbin[0, 1, 1] = 1
+    ch_nonbin[0, 1, 2] = 2
+    with pytest.raises(ValueError):
+        mob.check_inputs(ch_nonbin, [0], 1)
+
+
+def test_check_input_notbinary_landmap():
+    """Test that nonbinary land map raises error."""
+    land_nonbin = np.zeros((3, 3, 3))
+    land_nonbin[0, 1, 1] = 1
+    land_nonbin[0, 1, 2] = 2
+    ch_bin = np.zeros_like(land_nonbin)
+    with pytest.raises(ValueError):
+        mob.check_inputs(ch_bin, [0], 1, land_nonbin)
+
+
 def test_check_input_invalid_chmap():
     """Test that an invalid channel map input will throw an error."""
     with pytest.raises(TypeError):

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -155,69 +155,25 @@ time_window = 5
 
 def test_dry_decay():
     """Test dry fraction decay."""
-    dryfrac = mob.calc_chan_decay(chmap, fsurf, basevalue, time_window)
+    dryfrac = mob.calculate_channel_decay(chmap, fsurf, basevalue, time_window)
     assert np.all(dryfrac == np.array([[0.75, 0.6875, 0.625, 0.5625, 0.5]]))
 
 
 def test_planform_olap():
     """Test channel planform overlap."""
-    ophi = mob.calc_planform_overlap(chmap, fsurf, basevalue, time_window)
+    ophi = mob.calculate_planform_overlap(chmap, fsurf, basevalue, time_window)
     assert pytest.approx(ophi == np.array([[1., 0.66666667, 0.33333333,
                                             0., -0.33333333]]))
 
 
 def test_reworking():
     """Test reworking index."""
-    fr = mob.calc_reworking_fraction(chmap, fsurf, basevalue, time_window)
+    fr = mob.calculate_reworking_fraction(chmap, fsurf, basevalue, time_window)
     assert pytest.approx(fr == np.array([[0., 0.08333333, 0.16666667,
                                           0.25, 0.33333333]]))
 
 
 def test_channel_abandon():
     """Test channel abandonment function."""
-    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
+    ch_abandon = mob.calculate_channel_abandonment(chmap, basevalue, time_window)
     assert np.all(ch_abandon == np.array([[0., 0.25, 0.5, 0.75, 1.]]))
-
-
-def test_linear_fit():
-    """Test linear curve fitting."""
-    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
-    yfit, cov, err = mob.mobility_curve_fit(ch_abandon, fit='linear')
-    assert pytest.approx(yfit == np.array([4.76315477e-24, 2.50000000e-01,
-                                           5.00000000e-01, 7.50000000e-01,
-                                           1.00000000e+00]))
-    assert pytest.approx(cov == np.array([[1.76300984e-25, -0.00000000e+00],
-                                          [0.00000000e+00,  5.28902953e-24]]))
-    assert pytest.approx(err == np.array([4.19882108e-13, 2.29978902e-12]))
-
-
-def test_harmonic_fit():
-    """Test harmonic curve fitting."""
-    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
-    yfit, cov, err = mob.mobility_curve_fit(ch_abandon, fit='harmonic')
-    assert pytest.approx(yfit == np.array([-0.25986438, 0.41294455,
-                                           0.11505591, 0.06683947,
-                                           0.04710091]))
-    assert pytest.approx(cov == np.array([[0.50676407, 1.26155952],
-                                          [1.26155952, 4.3523343]]))
-    assert pytest.approx(err == np.array([0.71187364, 2.08622489]))
-
-
-def test_invalid_fit():
-    """Test invalid fit parameter."""
-    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
-    with pytest.raises(ValueError):
-        mob.mobility_curve_fit(ch_abandon, fit='invalid')
-
-
-def test_exponential_fit():
-    """Test exponential fitting."""
-    ydata = np.array([10, 5, 2, 1])
-    yfit, cov, err = mob.mobility_curve_fit(ydata, fit='exponential')
-    assert pytest.approx(yfit == np.array([10.02900253, 4.85696353,
-                                           2.22612537, 0.88790858]))
-    assert pytest.approx(cov == np.array([[0.0841566, 0.04554967, 0.01139969],
-                                          [0.04554967, 0.59895713, 0.08422946],
-                                          [0.01139969, 0.08422946,
-                                           0.01327807]]))
-    assert pytest.approx(err == np.array([0.29009757, 0.77392321, 0.11523053]))

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -1,0 +1,204 @@
+"""Tests for mobility.py."""
+import pytest
+import sys
+import os
+import numpy as np
+
+import deltametrics as dm
+from deltametrics import cube
+from deltametrics import mobility as mob
+
+# initialize a cube directly from path, rather than using sample_data.py
+rcm8_path = os.path.join(os.path.dirname(__file__), '..', 'deltametrics',
+                         'sample_data', 'files', 'pyDeltaRCM_Output_8.nc')
+rcm8cube = cube.DataCube(rcm8_path)
+# define some masks once up top
+chmask = dm.mask.ChannelMask(rcm8cube['velocity'][20:23, :, :],
+                             rcm8cube['eta'][20:23, :, :])
+landmask = dm.mask.LandMask(rcm8cube['eta'][20:23, :, :])
+
+
+def test_check_input_mask():
+    """Test that a deltametrics.mask.BaseMask type can be used."""
+    # call checker function
+    chmap, landmap, basevalues, time_window = mob.check_inputs(chmask,
+                                                               [0], 1,
+                                                               landmask)
+    # assert types
+    assert isinstance(chmap, np.ndarray) is True
+    assert isinstance(landmap, np.ndarray) is True
+    assert isinstance(basevalues, list) is True
+    assert isinstance(time_window, int) is True
+
+
+@pytest.mark.xfail()
+def test_check_xarrays():
+    """Test that an xarray.DataArray can be used as an input."""
+    # call checker function
+    chmap, landmap, basevalues, time_window = mob.check_inputs(ch_xarr,
+                                                               [0], 1,
+                                                               land_xarr)
+    # assert types
+    assert isinstance(chmap, np.ndarray) is True
+    assert isinstance(landmap, np.ndarray) is True
+    assert isinstance(basevalues, list) is True
+    assert isinstance(time_window, int) is True
+
+
+def test_check_input_nolandmask():
+    """Test that the check input can run without a landmap."""
+    # call checker function
+    chmap, landmap, basevalues, time_window = mob.check_inputs(chmask,
+                                                               [0], 1)
+    # assert types
+    assert isinstance(chmap, np.ndarray) is True
+    assert landmap is None
+    assert isinstance(basevalues, list) is True
+    assert isinstance(time_window, int) is True
+
+
+def test_check_input_invalid_chmap():
+    """Test that an invalid channel map input will throw an error."""
+    with pytest.raises(TypeError):
+        mob.check_inputs('invalid', [0], 1, landmask)
+
+
+def test_check_input_invalid_landmap():
+    """Test that an invalid landmap will throw an error."""
+    with pytest.raises(TypeError):
+        mob.check_inputs(chmask, [0], 1, 'invalid')
+
+
+def test_check_inputs_basevalues_nonlist():
+    """Test that a non-list input as basevalues throws an error."""
+    with pytest.raises(TypeError):
+        mob.check_inputs(chmask, 0, 1)
+
+
+def test_check_input_invalid_time_window():
+    """Test that a non-valid time_window throws an error."""
+    with pytest.raises(TypeError):
+        mob.check_inputs(chmask, [0], 'invalid')
+
+
+def test_check_input_2dchanmask():
+    """Test that an unexpected channel mask shape throws an error."""
+    with pytest.raises(ValueError):
+        mob.check_inputs(np.ones((5,)), [0], 1)
+
+
+def test_check_input_diff_shapes():
+    """Test that differently shaped channel and land masks throw an error."""
+    with pytest.raises(ValueError):
+        mob.check_inputs(chmask, [0], 1, np.ones((3, 3, 3)))
+
+
+def test_check_input_1dlandmask():
+    """Test a 1d landmask that will throw an error."""
+    with pytest.raises(ValueError):
+        mob.check_inputs(chmask, [0], 1, np.ones((10, 1)))
+
+
+def test_check_input_exceedmaxvals():
+    """Test a basevalue + time window combo that exceeds time indices."""
+    with pytest.raises(ValueError):
+        mob.check_inputs(chmask, [0], 100)
+
+
+def test_check_input_castlandmap():
+    """Test ability to case a 2D landmask to match 3D channelmap."""
+    chmap, landmap, bv, tw = mob.check_inputs(chmask, [0], 1,
+                                              landmask.mask[0, :, :])
+    assert np.shape(chmap) == np.shape(landmap)
+
+
+# Test actual mobility functions using a simple example
+# domain is a small 4x4 region with a single 4 cell channel
+# every timestep, a cell from the channel moves over a column
+# colab notebook: https://colab.research.google.com/drive/1-lkswSZSGRkhsArLm245WMSiKvj03YyU?usp=sharing
+
+# first define the domain and channel maps etc.
+chmap = np.zeros((5, 4, 4))
+# define time = 0
+chmap[0, :, 1] = 1
+# every time step one cell of the channel will migrate one pixel to the right
+for i in range(1, 5):
+    chmap[i, :, :] = chmap[i-1, :, :].copy()
+    chmap[i, -1*i, 1] = 0
+    chmap[i, -1*i, 2] = 1
+# define the fluvial surface - entire 4x4 area
+fsurf = np.ones((4, 4))
+# define the index corresponding to the basemap at time 0
+basevalue = [0]
+# define the size of the time window to use
+time_window = 5
+
+
+def test_dry_decay():
+    """Test dry fraction decay."""
+    dryfrac = mob.calc_chan_decay(chmap, fsurf, basevalue, time_window)
+    assert np.all(dryfrac == np.array([[0.75, 0.6875, 0.625, 0.5625, 0.5]]))
+
+
+def test_planform_olap():
+    """Test channel planform overlap."""
+    ophi = mob.calc_planform_overlap(chmap, fsurf, basevalue, time_window)
+    assert pytest.approx(ophi == np.array([[1., 0.66666667, 0.33333333,
+                                            0., -0.33333333]]))
+
+
+def test_reworking():
+    """Test reworking index."""
+    fr = mob.calc_reworking_fraction(chmap, fsurf, basevalue, time_window)
+    assert pytest.approx(fr == np.array([[0., 0.08333333, 0.16666667,
+                                          0.25, 0.33333333]]))
+
+
+def test_channel_abandon():
+    """Test channel abandonment function."""
+    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
+    assert np.all(ch_abandon == np.array([[0., 0.25, 0.5, 0.75, 1.]]))
+
+
+def test_linear_fit():
+    """Test linear curve fitting."""
+    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
+    yfit, cov, err = mob.mobility_curve_fit(ch_abandon, fit='linear')
+    assert pytest.approx(yfit == np.array([4.76315477e-24, 2.50000000e-01,
+                                           5.00000000e-01, 7.50000000e-01,
+                                           1.00000000e+00]))
+    assert pytest.approx(cov == np.array([[1.76300984e-25, -0.00000000e+00],
+                                          [0.00000000e+00,  5.28902953e-24]]))
+    assert pytest.approx(err == np.array([4.19882108e-13, 2.29978902e-12]))
+
+
+def test_harmonic_fit():
+    """Test harmonic curve fitting."""
+    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
+    yfit, cov, err = mob.mobility_curve_fit(ch_abandon, fit='harmonic')
+    assert pytest.approx(yfit == np.array([-0.25986438, 0.41294455,
+                                           0.11505591, 0.06683947,
+                                           0.04710091]))
+    assert pytest.approx(cov == np.array([[0.50676407, 1.26155952],
+                                          [1.26155952, 4.3523343]]))
+    assert pytest.approx(err == np.array([0.71187364, 2.08622489]))
+
+
+def test_invalid_fit():
+    """Test invalid fit parameter."""
+    ch_abandon = mob.calc_chan_abandonment(chmap, basevalue, time_window)
+    with pytest.raises(ValueError):
+        mob.mobility_curve_fit(ch_abandon, fit='invalid')
+
+
+def test_exponential_fit():
+    """Test exponential fitting."""
+    ydata = np.array([10, 5, 2, 1])
+    yfit, cov, err = mob.mobility_curve_fit(ydata, fit='exponential')
+    assert pytest.approx(yfit == np.array([10.02900253, 4.85696353,
+                                           2.22612537, 0.88790858]))
+    assert pytest.approx(cov == np.array([[0.0841566, 0.04554967, 0.01139969],
+                                          [0.04554967, 0.59895713, 0.08422946],
+                                          [0.01139969, 0.08422946,
+                                           0.01327807]]))
+    assert pytest.approx(err == np.array([0.29009757, 0.77392321, 0.11523053]))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from deltametrics import utils
+from deltametrics import mobility as mob
 
 
 class TestNoStratigraphyError:
@@ -24,3 +25,67 @@ class TestNoStratigraphyError:
         _mtch = "'str' object has no attribute 'somevar'."
         with pytest.raises(utils.NoStratigraphyError, match=_mtch):
             raise utils.NoStratigraphyError('someobj', 'somevar')
+
+
+
+chmap = np.zeros((5, 4, 4))
+# define time = 0
+chmap[0, :, 1] = 1
+# every time step one cell of the channel will migrate one pixel to the right
+for i in range(1, 5):
+    chmap[i, :, :] = chmap[i-1, :, :].copy()
+    chmap[i, -1*i, 1] = 0
+    chmap[i, -1*i, 2] = 1
+# define the fluvial surface - entire 4x4 area
+fsurf = np.ones((4, 4))
+# define the index corresponding to the basemap at time 0
+basevalue = [0]
+# define the size of the time window to use
+time_window = 5
+
+
+def test_linear_fit():
+    """Test linear curve fitting."""
+    ch_abandon = mob.calculate_channel_abandonment(chmap, basevalue,
+                                                   time_window)
+    yfit, cov, err = utils.curve_fit(ch_abandon, fit='linear')
+    assert pytest.approx(yfit == np.array([4.76315477e-24, 2.50000000e-01,
+                                           5.00000000e-01, 7.50000000e-01,
+                                           1.00000000e+00]))
+    assert pytest.approx(cov == np.array([[1.76300984e-25, -0.00000000e+00],
+                                          [0.00000000e+00,  5.28902953e-24]]))
+    assert pytest.approx(err == np.array([4.19882108e-13, 2.29978902e-12]))
+
+
+def test_harmonic_fit():
+    """Test harmonic curve fitting."""
+    ch_abandon = mob.calculate_channel_abandonment(chmap, basevalue,
+                                                   time_window)
+    yfit, cov, err = utils.curve_fit(ch_abandon, fit='harmonic')
+    assert pytest.approx(yfit == np.array([-0.25986438, 0.41294455,
+                                           0.11505591, 0.06683947,
+                                           0.04710091]))
+    assert pytest.approx(cov == np.array([[0.50676407, 1.26155952],
+                                          [1.26155952, 4.3523343]]))
+    assert pytest.approx(err == np.array([0.71187364, 2.08622489]))
+
+
+def test_invalid_fit():
+    """Test invalid fit parameter."""
+    ch_abandon = mob.calculate_channel_abandonment(chmap, basevalue,
+                                                   time_window)
+    with pytest.raises(ValueError):
+        utils.curve_fit(ch_abandon, fit='invalid')
+
+
+def test_exponential_fit():
+    """Test exponential fitting."""
+    ydata = np.array([10, 5, 2, 1])
+    yfit, cov, err = utils.curve_fit(ydata, fit='exponential')
+    assert pytest.approx(yfit == np.array([10.02900253, 4.85696353,
+                                           2.22612537, 0.88790858]))
+    assert pytest.approx(cov == np.array([[0.0841566, 0.04554967, 0.01139969],
+                                          [0.04554967, 0.59895713, 0.08422946],
+                                          [0.01139969, 0.08422946,
+                                           0.01327807]]))
+    assert pytest.approx(err == np.array([0.29009757, 0.77392321, 0.11523053]))


### PR DESCRIPTION
This would go after #27.

## Summary
This PR provides at least an initial take at adding channel mobility metrics to the `deltametrics` framework. Nothing fancy was done, so we can have a discussion about tying these functions in more tightly to `deltametrics` objects (right now they are much more 'standalone' than other modules we have). But the 4 metrics added are the following:

1. Dry fraction decay per Cazanacli et al 2002

2. Channel Planform Overlap per Wickert et al 2013

3. Reworking Fraction per Wickert et al 2013

4. Channel Abandonment per Liang et al 2016

A demo of the current functionality is available [here](https://colab.research.google.com/drive/1-lkswSZSGRkhsArLm245WMSiKvj03YyU?usp=sharing). This PR does not include any substantial documentation beyond linking up the API reference, but in the future the plan would be to create documentation resembling that colab notebook.

## Details
More specifically, this PR adds the following:
- Allows for flexible type inputs to the mobility metrics
- Functions to compute the above mobility metrics
- Function for curve fitting linear, harmonic, and exponential functions
- Unit tests the methods against the simple 'demo' test in addition to standard error/exception checking
- Updates api reference to document these functions

This PR does **not** do the following:
- Add an example of using these metrics to the documentation
- Provide these functions as any kind of deltametrics class or object
- Create a new 'base' class of any kind
- Implement cool function names (I don't know that `calc_`"metric name here" is the nicest way to name a function)
- Add methods to create more general (geometric) base masks, this could be something that is added to the masking functions later (e.g. a method to create binary mask of a radial region).
- Manage the time dimension (these methods use indices from the arrays for setting `basevalues` and `time_windows`), in the future we could build-in the time 'units' via `xarray`

So like I said, I'm very flexible on changing the structure of these functions to better mesh with the deltametrics API, it was just not obvious to me what the best way of doing that would be. Part of my hesitation about writing a complex API / additional documentation is just due to the uncertainty around the merge order (will this go before or after #23 which breaks some bits of the API, either way I think the conflicts can be resolved without too much fuss). In conclusion, despite the shortcomings of this PR, I think it is still a step forward.