### PR TITLE
fix time decoding in xarray

### DIFF
--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -166,7 +166,7 @@ class NetCDFIO(BaseIO):
             _tempdataset.close()
 
         try:
-            _dataset = xr.open_dataset(self.data_path)
+            _dataset = xr.open_dataset(self.data_path, decode_times=False)
 
             if 'time' and 'y' and 'x' in _dataset.variables:
                 self.dataset = _dataset.set_coords(['time', 'y', 'x'])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -129,3 +129,10 @@ def test_readvar_intomemory_error():
 
     with pytest.raises(KeyError):
         netcdf_io.read('nonexistant')
+
+
+def test_read_time_correctly():
+    netcdf_io = io.NetCDFIO(rcm8_path, 'netcdf')
+    assert netcdf_io.dataset.time[-1] == 2500
+    # note that 2500 is the old time format, of saving timestep number.
+    # this will need to be updated if the underlying test dataset is changed.


### PR DESCRIPTION
'time' in the netcdf file was being decoded to nano-seconds precision `HH:MM:SS` style time from `xarray.open_dataset()` method. We add an option to not decode times when opening the dataset here, which fixes the time to remain as just a numeric.