### PR TITLE
Integrate meta

### DIFF
--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -210,6 +210,10 @@ class BaseCube(abc.ABC):
             self._dataio.read(var)
 
     @property
+    def meta(self):
+        return self._dataio.meta
+
+    @property
     def varset(self):
         """:class:`~deltametrics.plot.VariableSet` : Variable styling for plotting.
 

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -167,16 +167,21 @@ class NetCDFIO(BaseIO):
 
         try:
             _dataset = xr.open_dataset(self.data_path)
-
             if 'time' and 'y' and 'x' in _dataset.variables:
                 self.dataset = _dataset.set_coords(['time', 'y', 'x'])
             else:
                 self.dataset = _dataset.set_coords([])
                 warn('Dimensions "time", "y", and "x" not provided in the \
                       given data file.', UserWarning)
-
         except Exception:
             raise TypeError('File format out of scope for DeltaMetrics')
+
+        try:
+            _meta = xr.open_dataset(self.data_path, group='meta')
+            self.meta = _meta
+        except OSError:
+            warn('No associated metadata was found in the given data file.',
+                 UserWarning)
 
     def get_known_variables(self):
         """List known variables.

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -182,6 +182,7 @@ class NetCDFIO(BaseIO):
         except OSError:
             warn('No associated metadata was found in the given data file.',
                  UserWarning)
+            self.meta = None
 
     def get_known_variables(self):
         """List known variables.

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -229,7 +229,6 @@ class BaseSection(abc.ABC):
                                 _gottype=type(CubeInstance)))
         self.cube = CubeInstance
         self._variables = self.cube.variables
-        # self._name = self._name or name or self.section_type
         self.name = name  # use the setter to determine the _name
         self._compute_section_coords()
         self._compute_section_attrs()
@@ -246,10 +245,11 @@ class BaseSection(abc.ABC):
         else:
             # _name is already set
             if not (var is None):
-                warnings.warn(UserWarning("`name` argument supplied to \
-                    instantiated `Section` object. To change the name of \
-                    a Section, you must set the attribute directly with \
-                    `section._name = 'name'`."))
+                warnings.warn(
+                    UserWarning("`name` argument supplied to instantiated "
+                                "`Section` object. To change the name of "
+                                "a Section, you must set the attribute "
+                                "directly with `section._name = 'name'`."))
             # do nothing
 
     @abc.abstractmethod

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -821,8 +821,13 @@ class CircularSection(BaseSection):
             self.radius = self._input_radius
 
         if (self._input_origin is None):
-            land_width = np.minimum(utils.guess_land_width_from_land(
-                self.cube['eta'][-1, :, 0]), 5)
+            if (self.cube.meta is None):
+                # try and guess the value (should issue a warning?)
+                land_width = np.minimum(utils.guess_land_width_from_land(
+                    self.cube['eta'][-1, :, 0]), 5)
+            else:
+                # extract L0 from the cube
+                land_width = self.cube.meta['L0']
             self.origin = (int(self.cube.shape[2] / 2),
                            land_width)
         else:
@@ -935,8 +940,13 @@ class RadialSection(BaseSection):
 
         # determine the origin of the line
         if (self._input_origin is None):
-            land_width = np.minimum(utils.guess_land_width_from_land(
-                self.cube['eta'][-1, :, 0]), 5)
+            if (self.cube.meta is None):
+                # try and guess the value (should issue a warning?)
+                land_width = np.minimum(utils.guess_land_width_from_land(
+                    self.cube['eta'][-1, :, 0]), 5)
+            else:
+                # extract L0 from the cube
+                land_width = self.cube.meta['L0']
             self.origin = (int(self.cube.shape[2] / 2),
                            land_width)
         else:

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -43,6 +43,10 @@ class TestDataCubeNoStratigraphy:
         with pytest.raises(ValueError):
             nocube = cube.DataCube('./nonexistent/path.doc')
 
+    def test_warning_netcdf_no_metadata(self):
+        with pytest.warns(UserWarning):
+            rcm8cube = cube.DataCube(rcm8_path)
+
     def test_stratigraphy_from_eta(self):
         rcm8cube = cube.DataCube(rcm8_path)
         rcm8cube.stratigraphy_from('eta')

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -15,6 +15,7 @@ from deltametrics.sample_data import _get_rcm8_path, _get_landsat_path
 
 
 rcm8_path = _get_rcm8_path()
+golf_path = _get_golf_path()
 hdf_path = _get_landsat_path()
 
 
@@ -22,6 +23,7 @@ class TestDataCubeNoStratigraphy:
 
     # create a fixed cube for variable existing, type checks
     fixeddatacube = cube.DataCube(rcm8_path)
+    golfcube = cube.DataCube(golf_path)
 
     def test_init_cube_from_path_rcm8(self):
         rcm8cube = cube.DataCube(rcm8_path)
@@ -42,6 +44,9 @@ class TestDataCubeNoStratigraphy:
     def test_error_init_bad_extension(self):
         with pytest.raises(ValueError):
             nocube = cube.DataCube('./nonexistent/path.doc')
+
+    def test_metadata_present(self):
+        assert golfcube.meta is golfcube._dataio.meta
 
     def test_warning_netcdf_no_metadata(self):
         with pytest.warns(UserWarning):

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -11,7 +11,7 @@ from deltametrics import cube
 from deltametrics import plot
 from deltametrics import section
 from deltametrics import utils
-from deltametrics.sample_data import _get_rcm8_path, _get_landsat_path
+from deltametrics.sample_data import _get_golf_path, _get_rcm8_path, _get_landsat_path
 
 
 rcm8_path = _get_rcm8_path()
@@ -44,9 +44,6 @@ class TestDataCubeNoStratigraphy:
     def test_error_init_bad_extension(self):
         with pytest.raises(ValueError):
             nocube = cube.DataCube('./nonexistent/path.doc')
-
-    def test_metadata_present(self):
-        assert golfcube.meta is golfcube._dataio.meta
 
     def test_warning_netcdf_no_metadata(self):
         with pytest.warns(UserWarning):
@@ -148,6 +145,12 @@ class TestDataCubeNoStratigraphy:
     def test_fixeddatacube_init_sections(self):
         assert type(self.fixeddatacube.sections) is dict
         assert self.fixeddatacube.sections is self.fixeddatacube.section_set
+
+    def test_metadata_present(self):
+        assert self.golfcube.meta is self.golfcube._dataio.meta
+
+    def test_metadata_none_nometa(self):
+        assert self.fixeddatacube.meta is None
 
     def test_fixeddatacube_x(self):
         assert self.fixeddatacube.x.shape == (240,)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -127,3 +127,9 @@ def test_readvar_intomemory_error():
 
     with pytest.raises(KeyError):
         netcdf_io.read('nonexistant')
+
+
+def test_netcdf_no_metadata():
+    # works fine, because there is no `connect` call in io init
+    netcdf_io = io.NetCDFIO(rcm8_path, 'netcdf')
+    assert len(netcdf_io._in_memory_data.keys()) == 0

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -11,10 +11,11 @@ from deltametrics import cube
 from deltametrics import plot
 from deltametrics import section
 from deltametrics import utils
-from deltametrics.sample_data import _get_rcm8_path
+from deltametrics.sample_data import _get_rcm8_path, _get_golf_path
 
 
 rcm8_path = _get_rcm8_path()
+golf_path = _get_golf_path()
 
 
 # Test the basics of each different section type
@@ -189,6 +190,21 @@ class TestCircularSection:
         assert len(sacs2.variables) > 0
         assert sacs2.origin == (10, 0)
 
+    def test_standalone_instantiation_withmeta(self):
+        golfcube = cube.DataCube(golf_path)
+        sacs = section.CircularSection(golfcube, radius=30)
+        assert sacs.name == 'circular'
+        assert sacs.cube == golfcube
+        assert sacs.trace.shape[0] == 85
+        assert len(sacs.variables) > 0
+        assert sacs.origin[1] == golfcube.meta['L0']
+        sacs2 = section.CircularSection(golfcube, radius=30, origin=(10, 0))
+        assert sacs2.name == 'circular'
+        assert sacs2.cube == golfcube
+        assert sacs2.trace.shape[0] == 53
+        assert len(sacs2.variables) > 0
+        assert sacs2.origin == (10, 0)
+
     @pytest.mark.xfail(AttributeError, reason='Not called if no cube.')
     def no_radius_if_no_cube(self):
         sacs3 = section.CircularSection()
@@ -285,6 +301,19 @@ class TestRadialSection:
         assert sars3.trace.shape[0] == 31
         assert len(sars3.variables) > 0
         assert sars3.azimuth == 178
+        assert sars3.origin == (143, 18)
+
+    def test_standalone_instantiation_withmeta(self):
+        golfcube = cube.DataCube(golf_path)
+        sars = section.RadialSection(golfcube)
+        assert sars.origin[1] == golfcube.meta['L0']
+        sars1 = section.RadialSection(golfcube, azimuth=30)
+        assert sars.origin[1] == golfcube.meta['L0']
+        sars2 = section.RadialSection(golfcube, azimuth=103, origin=(90, 2))
+        assert sars2.origin == (90, 2)
+        sars3 = section.RadialSection(
+            golfcube, azimuth=178, origin=(143, 18), length=30, name='diff')
+        assert sars3.name == 'diff'
         assert sars3.origin == (143, 18)
 
     def test_register_section(self):


### PR DESCRIPTION
This pull request does some initial work to integrate `cube` metadata into the DeltaMetrics objects. 

- [x] complete some sample model runs with the proper metadata from [#104](https://github.com/DeltaRCM/pyDeltaRCM/pull/104)
- [x] integrate the model domain metadata into the `Section` default options, for if a cube is present.
- [ ] integrate the model domain metadata into the `Mask` default options, this one will be trickier, and maybe should wait for the `Mask` refactor, because `Mask` currently has no connection to the `Cube` (so would need to pass all domain metadata as arguments...)