### PR TITLE
Geometric masks

### DIFF
--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -916,3 +916,172 @@ class CenterlineMask(BaseMask):
             nms_norm = self.nms/self.nms.max()
             # compute mask
             self._mask = (nms_norm > self.nms_threshold) * 1
+
+
+class GeometricMask(BaseMask):
+    """Create simple geometric masks.
+
+    A geometric mask object, allows for creation of subdomains in multiple
+    ways. Angular boundaries can define an area of interest in the shape
+    of an arc. Radial boundaries can define a radial region to mask.
+    Boundaries defined in the strike direction (perpendicular to inlet
+    channel), can be supplied to define a region of interest. Similarly,
+    boundaries can be defined in the dip direction (parallel to inlet channel
+    orientation).
+
+    Examples
+    --------
+    Initialize the geometric mask using model topography as a base.
+        >>> arr = rcm8cube['eta'][-1, :, :]
+        >>> gmsk = dm.mask.GeometricMask(arr)
+
+    Define an angular mask to cover half the domain from 0 to pi/2.
+        >>> gmsk.angular(0, np.pi/2)
+
+    Further mask this region by defining some bounds in the strike direction.
+        >>> gmsk.strike(10, 50)
+
+    Visualize the mask:
+        >>> gmsk.show()
+
+    .. plot:: mask/geomask.py
+
+    """
+
+    def __init__(self, arr, is_mask=False):
+        """Initialize the GeometricMask.
+
+        Initializing the geometric mask object requires a 2-D array of the
+        region you wish to apply the mask to.
+
+        Parameters
+        ----------
+        arr : ndarray
+            2-D array to be masked.
+
+        is_mask : bool, optional
+            Whether the data in :obj:`arr` is already a binary mask. Default
+            value is False. This should be set to True, if you have already
+            binarized the data yourself, using custom routines, or want to
+            further mask a pre-existing mask using geometric boundaries, this
+            should be set to True.
+
+        """
+        super().__init__(mask_type='geometric', data=arr)
+
+        if is_mask is False:
+            self._mask = np.ones_like(self.data)
+        elif is_mask is True:
+            self._mask = self.data
+        else:
+            raise TypeError('is_mask must be a `bool`,'
+                            'but was: ' + str(type(is_mask)))
+
+        _, self.L, self.W = np.shape(self._mask)
+        self.xc = int(self.L/2)
+        self.yc = int(self.W/2)
+
+    def angular(self, theta1, theta2):
+        """Make a mask based on two angles.
+
+        Computes a mask that is bounded by 2 angles input by the user. The
+        origin is the center of the edge where the inlet is assumed to exist.
+
+        Parameters
+        ----------
+        theta1 : float
+            Radian value controlling the left bound of the mask
+
+        theta2 : float
+            Radian value controlling the right bound of the mask
+
+        """
+        y, x = np.ogrid[0:self.W, -self.L:self.L]
+        theta = np.arctan2(x, y) - theta1 + np.pi/2
+        theta %= (2*np.pi)
+        anglemask = theta <= (theta2-theta1)
+        anglemap = anglemask[:self.L, :self.W]
+
+        self._mask = self._mask * anglemap
+
+    def radial(self, rad1, rad2=None):
+        """Make a mask based on two radii.
+
+        Computes a mask that is bounded by 2 radial distances which are input
+        by the user. The origin is assumed to be the center of the edge where
+        we assume the inlet is.
+
+        Parameters
+        ----------
+        rad1 : int
+            Index value to set the inner radius.
+
+        rad2 : int, optional
+            Index value to set the outer radius. If unspecified, this bound
+            is set to extend as the length of the domain.
+
+        """
+        if rad2 is None:
+            rad2 = self.L
+        yy, xx = np.meshgrid(range(self.W), range(self.L))
+        # calculate array of distances from inlet
+        raddist = np.sqrt((yy-self.yc)**2 + xx**2)
+        # identify points within radial bounds
+        raddist = np.where(raddist >= rad1, raddist, 0)
+        raddist = np.where(raddist <= rad2, raddist, 0)
+        raddist = np.where(raddist == 0, raddist, 1)
+        # make 3D to be consistent with mask
+        raddist = np.reshape(raddist, [1, self.L, self.W])
+        # combine with current mask via multiplication
+        self._mask = self._mask * raddist
+
+    def strike(self, ind1, ind2=None):
+        """Make a mask based on two indices.
+
+        Makes a mask bounded by lines perpendicular to the direction of the
+        flow in the inlet channel.
+
+        Parameters
+        ----------
+        ind1 : int
+            Index value to set first boundary (closest to inlet)
+
+        ind2 : int, optional
+            Index value to set second boundary (farther from inlet). This is
+            optional, if unspecified, this is set to the length of the domain.
+
+        """
+        if ind2 is None:
+            ind2 = self.L
+        temp_mask = np.zeros_like(self._mask)
+        temp_mask[:, ind1:ind2, :] = 1
+
+        self._mask = self._mask * temp_mask
+
+    def dip(self, ind1, ind2=None):
+        """Make a mask parallel to the inlet.
+
+        Makes a mask that is parallel to the direction of flow in the inlet.
+        If only one value is supplied, then this mask is centered on the
+        inlet and has a width of ind1. If two values are supplied then they
+        set the bounds for the mask.
+
+        Parameters
+        ----------
+        ind1 : int
+            Width of the mask if ind2 is not specified. Otherwise, it sets
+            the left bound of the mask.
+
+        ind2 : int, optional
+            Right bound of the mask if specified. If not specified, then
+            ind1 sets the width of a mask centered on the inlet.
+
+        """
+        temp_mask = np.zeros_like(self._mask)
+        if ind2 is None:
+            w_ind = int(ind1/2)
+            temp_mask[:, :, self.yc-w_ind:self.yc+w_ind] = 1
+        else:
+            temp_mask[:, :, ind1:ind2] = 1
+
+        self._mask = self._mask * temp_mask

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -386,3 +386,32 @@ def calculate_channel_abandonment(chmap, basevalues, time_window):
             PwetA[i, Nstep] = stepA/baseA
 
     return PwetA
+
+
+def channel_presence(chmap):
+    """
+    Calculate the normalized channel presence at each pixel location.
+
+    Measure the normalized fraction of time a given pixel is channelized,
+    based on method in Liang et al 2016. This requires providing a 3-D input
+    channel map (t-x-y).
+
+    Parameters
+    ----------
+    chmap : ndarray
+        A t-x-y shaped array with binary channel maps
+
+    Returns
+    -------
+    channel_presence : ndarray
+        A x-y shaped array with the normalized channel presence values.
+
+    """
+    if isinstance(chmap, mask.ChannelMask) is True:
+        chans = chmap._mask
+    elif isinstance(chmap, np.ndarray) is True:
+        chans = chmap
+    else:
+        raise TypeError('chmap data type not understood.')
+    channel_presence = np.sum(chans, axis=0) / chans.shape[0]
+    return channel_presence

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -714,6 +714,105 @@ class TestCenterlineMask:
         assert hasattr(centerlinemask, 'mask') is True
 
 
+class TestGeometricMask:
+    """Tests associated with the mask.GeometricMask class."""
+
+    def test_initialize_gm(self):
+        """Test initialization."""
+        arr = np.zeros((1, 10, 10))
+        gmsk = mask.GeometricMask(arr)
+        assert gmsk.mask_type == 'geometric'
+        assert np.shape(gmsk._mask) == np.shape(arr)
+        assert np.all(gmsk._mask == 1)
+        assert gmsk._xc == 0
+        assert gmsk._yc == 5
+        assert gmsk.xc == gmsk._xc
+        assert gmsk.yc == gmsk._yc
+
+    def test_initialize_wrong_ismask(self):
+        """Test with bad input mask."""
+        arr = np.zeros((1, 10, 10))
+        arr[0, 1, 1] = 1
+        arr[0, 0, 0] = 5  # make input non-binary
+        with pytest.raises(TypeError):
+            mask.GeometricMask(arr, is_mask='blah')
+
+    def test_initialize_with_mask(self):
+        """Test init with mask."""
+        msk = np.zeros((1, 10, 10))
+        msk[0, 0, :] = 1
+        gmsk = mask.GeometricMask(msk, is_mask=True)
+        assert np.all(gmsk._mask == msk)
+
+    def test_circular_default(self):
+        """Test circular mask with defaults, small case."""
+        arr = np.zeros((1, 5, 5))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.circular(1)
+        assert gmsk._mask[0, 0, 2] == 0
+
+    def test_circular_2radii(self):
+        """Test circular mask with 2 radii, small case."""
+        arr = np.zeros((1, 7, 7))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.circular(1, 2)
+        assert gmsk._mask[0, 0, 3] == 0
+        assert np.all(gmsk._mask[0, :, -1] == 0)
+        assert np.all(gmsk._mask[0, :, 0] == 0)
+        assert np.all(gmsk._mask[0, -1, :] == 0)
+
+    def test_circular_custom_origin(self):
+        """Test circular mask with defined origin."""
+        arr = np.zeros((1, 7, 7))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.circular(1, 2, origin=(3, 3))
+        assert gmsk._mask[0, 3, 3] == 0
+        assert np.all(gmsk._mask == np.array([[[0., 0., 0., 0., 0., 0., 0.],
+                                               [0., 0., 0., 1., 0., 0., 0.],
+                                               [0., 0., 1., 1., 1., 0., 0.],
+                                               [0., 1., 1., 0., 1., 1., 0.],
+                                               [0., 0., 1., 1., 1., 0., 0.],
+                                               [0., 0., 0., 1., 0., 0., 0.],
+                                               [0., 0., 0., 0., 0., 0., 0.]]])
+                      )
+        assert gmsk.xc == 3
+        assert gmsk.yc == 3
+
+    def test_strike_one(self):
+        """Test strike masking with one value."""
+        arr = np.zeros((1, 7, 7))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.strike(2)
+        assert np.all(gmsk._mask[0, :2, :] == 0)
+        assert np.all(gmsk._mask[0, 2:, :] == 1)
+
+    def test_strike_two(self):
+        """Test strike masking with two values."""
+        arr = np.zeros((1, 7, 7))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.strike(2, 4)
+        assert np.all(gmsk._mask[0, :2, :] == 0)
+        assert np.all(gmsk._mask[0, 2:4, :] == 1)
+        assert np.all(gmsk._mask[0, 4:, :] == 0)
+
+    def test_dip_one(self):
+        """Test dip masking with one value."""
+        arr = np.zeros((1, 7, 7))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.dip(5)
+        assert np.all(gmsk._mask[0, :, 1:-1] == 1)
+        assert np.all(gmsk._mask[0, :, 0] == 0)
+        assert np.all(gmsk._mask[0, :, -1] == 0)
+
+    def test_dip_two(self):
+        """Test dip masking with two values."""
+        arr = np.zeros((1, 7, 7))
+        gmsk = mask.GeometricMask(arr)
+        gmsk.dip(2, 4)
+        assert np.all(gmsk._mask[0, :, 0:2] == 0)
+        assert np.all(gmsk._mask[0, :, 2:4] == 1)
+        assert np.all(gmsk._mask[0, :, 4:] == 0)
+
 def test_plotter(tmp_path):
     """Test the show() function."""
     import matplotlib.pyplot as plt

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -813,6 +813,25 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[0, :, 2:4] == 1)
         assert np.all(gmsk._mask[0, :, 4:] == 0)
 
+    def test_angular_half(self):
+        """Test angular mask over half of domain"""
+        arr = np.zeros((1, 100, 200))
+        gmsk = mask.GeometricMask(arr)
+        theta1 = 0
+        theta2 = np.pi/2
+        gmsk.angular(theta1, theta2)
+        # assert 1s half
+        assert np.all(gmsk._mask[-1, :, :101] == 1)
+        assert np.all(gmsk._mask[-1, :, 101:] == 0)
+
+    def test_angular_bad_dims(self):
+        """raise error."""
+        arr = np.zeros((5, 5))
+        gmsk = mask.GeometricMask(arr)
+        with pytest.raises(ValueError):
+            gmsk.angular(0, np.pi/2)
+
+
 def test_plotter(tmp_path):
     """Test the show() function."""
     import matplotlib.pyplot as plt

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -177,3 +177,12 @@ def test_channel_abandon():
     """Test channel abandonment function."""
     ch_abandon = mob.calculate_channel_abandonment(chmap, basevalue, time_window)
     assert np.all(ch_abandon == np.array([[0., 0.25, 0.5, 0.75, 1.]]))
+
+
+def test_channel_presence():
+    """Test channel presence."""
+    chan_presence = mob.channel_presence(chmap)
+    assert np.all(chan_presence == np.array([[0., 0.8, 0.2, 0.],
+                                             [0., 0.6, 0.4, 0.],
+                                             [0., 0.4, 0.6, 0.],
+                                             [0., 0.2, 0.8, 0.]]))


### PR DESCRIPTION
Some basic geometric masking functions.

Right now the angular mask is not as flexible as I'd like so there's a note in the doc-string with what will eventually be improved. Will open up issues to create some documentation for these new masks and to fix the angular mask. But basically you can define and combine masks to get something like this:

![image](https://user-images.githubusercontent.com/1770513/98309742-d7ba6200-1f90-11eb-9931-9f6c249e167e.png)


Also adds a `channel presence()` function which returns an array of normalized channel presence (fraction of time channelized) given a 3-D array of channel masks. This is a pretty popular visualization of DeltaRCM results. 

Relates to #31.