### PR TITLE
Minor implements

### DIFF
--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -521,7 +521,11 @@ class ChannelMask(BaseMask):
             will be coerced to `boolean`.
         """
         # set directly
-        raise NotImplementedError
+        _CM = ChannelMask(allow_empty=True)
+        _CM._set_shape_mask(_arr.shape)
+        _CM._input_flag = None
+        _CM._mask = _arr.astype(np.bool)  # set the array as mask
+        return _CM
 
     def __init__(self, *args, is_mask=None, **kwargs):
         """Initialize the ChannelMask.
@@ -1129,6 +1133,7 @@ class ShorelineMask(BaseMask):
             will be coerced to `boolean`.
         """
         _SM = ShorelineMask(allow_empty=True)
+        _SM._set_shape_mask(_arr.shape)
         _SM._angle_threshold = None
         _SM._input_flag = None
         _SM._mask = _arr.astype(np.bool)  # set the array as mask

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -544,7 +544,7 @@ def aerial_colormap():
     raise NotImplementedError
 
 
-def append_colorbar(ci, ax, size=2):
+def append_colorbar(ci, ax, size=2, **kwargs):
     """Append a colorbar, consistently placed.
 
     Adjusts some parameters of the parent axes as well.
@@ -562,6 +562,9 @@ def append_colorbar(ci, ax, size=2):
         Whether to adjust some minor attributes of the parent axis, for
         presentation.
 
+    **kwargs
+        Passed to `matplotlib.pyplot.colorbar`.
+
     Returns
     -------
     cb : `matplotlib.colorbar` instance.
@@ -569,7 +572,7 @@ def append_colorbar(ci, ax, size=2):
     """
     divider = axtk.axes_divider.make_axes_locatable(ax)
     cax = divider.append_axes("right", size=str(size)+"%", pad=0.05)
-    cb = plt.colorbar(ci, cax=cax)
+    cb = plt.colorbar(ci, cax=cax, **kwargs)
     cb.ax.tick_params(labelsize=9)
     ax.use_sticky_edges = False
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -346,6 +346,7 @@ class TestShorelineMask:
 
         shoremask = mask.ShorelineMask.from_array(_arr)
         # make assertions
+        assert shoremask.mask_type == 'shoreline'
         assert shoremask._input_flag is None
         assert np.all(shoremask._mask == _arr)
 
@@ -356,6 +357,7 @@ class TestShorelineMask:
 
         shoremask2 = mask.ShorelineMask.from_array(_arr2)
         # make assertions
+        assert shoremask2.mask_type == 'shoreline'
         assert shoremask2._input_flag is None
         assert np.all(shoremask2._mask == _arr2_bool)
 
@@ -1101,14 +1103,30 @@ class TestChannelMask:
         assert np.all(channelmask_comp._mask == mfem2._mask)
         assert np.all(mfem._mask == mfem2._mask)
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
+    # @pytest.mark.xfail(raises=NotImplementedError, strict=True,
+    #                    reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
-        channelmask = mask.ChannelMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        channelmask = mask.ChannelMask.from_array(_arr)
         # make assertions
-        assert channelmask._input_flag == 'channel'
+        assert channelmask.mask_type == 'channel'
+        assert channelmask._input_flag is None
+        assert np.all(channelmask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(np.bool)
+
+        assert _arr2.dtype == np.float
+
+        channelmask2 = mask.ChannelMask.from_array(_arr2)
+        # make assertions
+        assert channelmask2.mask_type == 'channel'
+        assert channelmask2._input_flag is None
+        assert np.all(channelmask2._mask == _arr2_bool)
 
 
 class TestEdgeMask:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -3,6 +3,8 @@ import pytest
 import sys
 import os
 
+import unittest.mock as mock
+
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
@@ -15,6 +17,7 @@ from deltametrics.sample_data import _get_rcm8_path
 
 
 rcm8_path = _get_rcm8_path()
+
 
 class TestVariableInfo:
 
@@ -93,7 +96,7 @@ class TestVariableSet:
         assert isinstance(vs.velocity, plot.VariableInfo)
         assert isinstance(vs.strata_sand_frac, plot.VariableInfo)
         assert isinstance(vs.sedflux, plot.VariableInfo)
-        
+
     def test_initialize_VariableSet_override_known_VariableInfo(self):
         vi = plot.VariableInfo('depth')
         od = {'depth': vi}
@@ -150,13 +153,37 @@ class TestVariableSet:
             vs.fakevariable = 'Yellow!'
 
 
-def test_append_colorbar():
-    _arr = np.random.randint(0, 100, size=(50, 50))
-    fig, ax = plt.subplots()
-    im = ax.imshow(_arr)
-    cb = plot.append_colorbar(im, ax)
-    assert isinstance(cb, matplotlib.colorbar.Colorbar)
-    assert ax.use_sticky_edges is False
+class TestAppendColorbar:
+
+    def test_append_colorbar_working(self):
+        """Test that the routine works.
+        Doesn't really make any meaningful assertions.
+        """
+        _arr = np.random.randint(0, 100, size=(50, 50))
+        fig, ax = plt.subplots()
+        im = ax.imshow(_arr)
+        cb = plot.append_colorbar(im, ax)
+        assert isinstance(cb, matplotlib.colorbar.Colorbar)
+        assert ax.use_sticky_edges is False
+
+    def test_size_argument_passed(self):
+        """Test that the routine works.
+        Doesn't really make any meaningful assertions.
+        """
+        _arr = np.random.randint(0, 100, size=(50, 50))
+        fig, ax = plt.subplots()
+        im = ax.imshow(_arr)
+        cb = plot.append_colorbar(im, ax, size=10)
+        assert isinstance(cb, matplotlib.colorbar.Colorbar)
+
+    def test_kwargs_argument_passed(self):
+        _arr = np.random.randint(0, 100, size=(50, 50))
+        fig, ax = plt.subplots()
+        im = ax.imshow(_arr)
+        _formatter = plt.FuncFormatter(lambda val, loc: np.round(val, 0))
+        cb = plot.append_colorbar(im, ax, size=10, format=_formatter)
+        assert isinstance(cb, matplotlib.colorbar.Colorbar)
+        assert cb.formatter is _formatter
 
 
 class TestFillSteps:


### PR DESCRIPTION
A few minor implementations.

* add ability to pass kwargs to colorbar instantiation in `plot._append_colorbar` use. This is helpful for specifying e.g., tick label formatter for plots. Adds test.
* implement the `from_array` pathway for `ChannelMask`. Update tests.


progress on #47 