### PR TITLE
Irregular-spaced shoreline position computation

### DIFF
--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -757,6 +757,20 @@ def compute_shoreline_distance(shore_mask, origin=[0, 0],
 
     Examples
     --------
+
+    .. doctest::
+
+        golf = dm.sample_data.golf()
+
+        sm = dm.mask.ShorelineMask(
+            golf['eta'][-1, :, :],
+            elevation_threshold=0,
+            elevation_offset=-0.5)
+
+        # compute mean and stddev distance
+        mean, stddev = dm.plan.compute_shoreline_distance(
+            sm, origin=[golf.meta['CTR'].data, golf.meta['L0'].data])
+
     """
     # check if mask or already array
     if isinstance(shore_mask, mask.ShorelineMask):

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -748,12 +748,16 @@ def compute_shoreline_distance(shore_mask, origin=[0, 0],
 
     Returns
     -------
-    length : :obj:`float`
-        Shoreline length, computed as described above.
+    mean : :obj:`float`
+        Mean shoreline distance.
 
-    line : :obj:`np.ndarray`
-        If :obj:`return_line` is `True`, the shoreline, as an ``Nx2`` array of
-        x-y points, is returned.
+    stddev : :obj:`float`
+        Standard deviation of shoreline distance.
+
+    distances : :obj:`np.ndarray`
+        If :obj:`return_distances` is `True`, then distance to each point
+        along the shoreline is *also* returned as an array (i.e., 3 arguments
+        are returned).
 
     Examples
     --------
@@ -791,7 +795,7 @@ def compute_shoreline_distance(shore_mask, origin=[0, 0],
     _dists = np.sqrt((_x - origin[0])**2 + (_y - origin[1])**2)
 
     if return_distances:
-        return _dists
+        return np.nanmean(_dists), np.nanstd(_dists), _dists
     else:
         return np.nanmean(_dists), np.nanstd(_dists)
 

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -717,8 +717,8 @@ def compute_shoreline_length(shore_mask, origin=[0, 0], return_line=False):
         return length
 
 
-def compute_delta_shoreline_distance(shore_mask, origin=[0, 0],
-                                     return_distances=False):
+def compute_shoreline_distance(shore_mask, origin=[0, 0],
+                               return_distances=False):
     """Compute mean and stddev distance from the delta apex to the shoreline.
 
     Algorithm computes the mean distance from the delta apex/origin to all

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -717,6 +717,71 @@ def compute_shoreline_length(shore_mask, origin=[0, 0], return_line=False):
         return length
 
 
+def compute_delta_shoreline_distance(shore_mask, origin=[0, 0],
+                                     return_distances=False):
+    """Compute mean and stddev distance from the delta apex to the shoreline.
+
+    Algorithm computes the mean distance from the delta apex/origin to all
+    shoreline points.
+
+    .. important::
+
+        This calculation is subtly different than the "mean delta radius",
+        because the measurements are not sampled evenly along the opening
+        angle of the delta.
+
+    .. note:: uses `np.nanmean` and `np.nanstd`.
+
+    Parameters
+    ----------
+    shore_mask : :obj:`~deltametrics.mask.ShorelineMask`, :obj:`ndarray`
+        Shoreline mask. Can be a :obj:`~deltametrics.mask.ShorelineMask`
+        object, or a binarized array.
+
+    origin : :obj:`list`, :obj:`np.ndarray`, optional
+        Determines the location from where the distance to all shoreline
+        points is computed.
+
+    return_distances : :obj:`bool`
+        Whether to return the sorted line as a second argument. If True, a
+        ``Nx2`` array of x-y points is returned. Default is `False`.
+
+    Returns
+    -------
+    length : :obj:`float`
+        Shoreline length, computed as described above.
+
+    line : :obj:`np.ndarray`
+        If :obj:`return_line` is `True`, the shoreline, as an ``Nx2`` array of
+        x-y points, is returned.
+
+    Examples
+    --------
+    """
+    # check if mask or already array
+    if isinstance(shore_mask, mask.ShorelineMask):
+        _sm = shore_mask.mask
+    else:
+        _sm = shore_mask
+
+    if not (np.sum(_sm) > 0):
+        raise ValueError('No pixels in shoreline mask.')
+
+    if _sm.ndim == 3:
+        _sm = _sm.squeeze()
+
+    # find where the mask is True (all x-y pairs along shore)
+    _y, _x = np.argwhere(_sm).T
+
+    # determine the distances
+    _dists = np.sqrt((_x - origin[0])**2 + (_y - origin[1])**2)
+
+    if return_distances:
+        return _dists
+    else:
+        return np.nanmean(_dists), np.nanstd(_dists)
+
+
 @njit
 def _compute_angles_between(c1, shoreandborder, Shallowsea, numviews):
     """Private helper for shaw_opening_angle_method.

--- a/docs/source/reference/plan/index.rst
+++ b/docs/source/reference/plan/index.rst
@@ -27,4 +27,5 @@ Functions
 
 	compute_shoreline_roughness
 	compute_shoreline_length
+    compute_shoreline_distance
 	shaw_opening_angle_method

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -293,10 +293,12 @@ class TestShorelineDistance:
         m, s = plan.compute_shoreline_distance(
             self.sm, origin=[self.golf.meta['CTR'].data,
                              self.golf.meta['L0'].data])
-        dists = plan.compute_shoreline_distance(
+        m2, s2, dists = plan.compute_shoreline_distance(
             self.sm, origin=[self.golf.meta['CTR'].data,
                              self.golf.meta['L0'].data],
             return_distances=True)
 
         assert len(dists) > 0
         assert np.mean(dists) == m
+        assert m2 == m
+        assert s2 == s

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -252,3 +252,34 @@ class TestShorelineLength:
             plt.show()
             breakpoint()
         assert len_1 == pytest.approx(self.rcm8_expected, abs=5.0)
+
+
+class TestShorelineDistance:
+
+    golf_path = _get_golf_path()
+    golf = cube.DataCube(golf_path)
+
+    sm = mask.ShorelineMask(
+        golf['eta'][-1, :, :],
+        elevation_threshold=0,
+        elevation_offset=-0.5)
+
+    def test_single_point(self):
+        _arr = np.zeros((10, 10))
+        _arr[7, 5] = 1
+        mean00, stddev00 = plan.compute_shoreline_distance(
+            _arr)
+        mean05, stddev05 = plan.compute_shoreline_distance(
+            _arr, origin=[5, 0])
+        assert mean00 == np.sqrt(49 + 25)
+        assert mean05 == 7
+        assert stddev00 == 0
+        assert stddev05 == 0
+
+    def test_simple_case(self):
+        mean, stddev = plan.compute_shoreline_distance(
+            self.sm, origin=[self.golf.meta['CTR'].data,
+                             self.golf.meta['L0'].data])
+
+        assert mean > stddev
+        assert stddev > 0

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -264,6 +264,11 @@ class TestShorelineDistance:
         elevation_threshold=0,
         elevation_offset=-0.5)
 
+    def test_empty(self):
+        _arr = np.zeros((10, 10))
+        with pytest.raises(ValueError):
+            _, _ = plan.compute_shoreline_distance(_arr)
+
     def test_single_point(self):
         _arr = np.zeros((10, 10))
         _arr[7, 5] = 1
@@ -283,3 +288,15 @@ class TestShorelineDistance:
 
         assert mean > stddev
         assert stddev > 0
+
+    def test_simple_case_distances(self):
+        m, s = plan.compute_shoreline_distance(
+            self.sm, origin=[self.golf.meta['CTR'].data,
+                             self.golf.meta['L0'].data])
+        dists = plan.compute_shoreline_distance(
+            self.sm, origin=[self.golf.meta['CTR'].data,
+                             self.golf.meta['L0'].data],
+            return_distances=True)
+
+        assert len(dists) > 0
+        assert np.mean(dists) == m


### PR DESCRIPTION
A function to compute the mean and std dev to the shoreline. This method uses irregular sampling, which makes it relatively straightforward and computationally efficient, but it may not always match user intuition (for example in the presence of an estuary).

I have opened an issue to create a companion function that implements a regular sampling approach (#57).


Todo
 - [x] docs
 - [x] tests