### PR TITLE
fix missing printed code string in shoreline roughness

### DIFF
--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -469,6 +469,7 @@ def compute_shoreline_roughness(shore_mask, land_mask, **kwargs):
     :meth:`~deltametrics.mask.BaseMask.trim_mask` method to trim a mask.
 
     .. plot::
+        :include-source:
         :context: close-figs
 
         lm0.trim_mask(length=golf.meta['L0'].data+1)


### PR DESCRIPTION
Code was not printed for the explanation of using `trim_mask` in the example with shoreline roughness.

PR fixes that.