### PR TITLE
Channel measures

### DIFF
--- a/deltametrics/_version.py
+++ b/deltametrics/_version.py
@@ -3,4 +3,4 @@ def __version__():
     """
     Private version declaration, gets assigned to dm.__version__ during import
     """
-    return '0.1.0'
+    return '0.2.0'

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1055,7 +1055,8 @@ def compute_channel_depth(channelmask, depth, section=None,
 
     Compute the depth of channels identified in a ChannelMask along a section.
     This function identifies the individual channels that are crossed by the
-    section and *computes depth of each*. The depths are then treated as individual samples for aggregating statistics in the return.
+    section and *computes depth of each*. The depths are then treated as
+    samples for aggregating statistics in the return.
 
     By default, only the mean and standard deviation are returned, but the
     list of depths can be returned with `return_depths=True`.
@@ -1071,12 +1072,20 @@ def compute_channel_depth(channelmask, depth, section=None,
         The channel mask (i.e., should be binary) to compute channel depths
         from.
 
+    depth : `xarray` or `ndarray`
+        The depth field corresponding to the channelmask array.
+
     section : :obj:`~deltametrics.section.BaseSection` subclass, or :obj:`ndarray`
         The section along which to compute channel depths. If a `Section` type
         is passed, the `.trace` attribute will be used to query the
         `ChannelMask` and determine depths. Otherwise, an `Nx2` array can be
         passed, which specified the x-y coordinate pairs to use as the
         trace.
+
+    depth_type : :obj:`str` 
+        Flag indicating how to compute the depth of *each* channel
+        (i.e., before aggregating). Valid flags are `'thalweg'`(default) and
+        `'mean'`.
 
     return_depths : bool, optional
         Whether to return (as third argument) a list of channel depths.
@@ -1093,16 +1102,6 @@ def compute_channel_depth(channelmask, depth, section=None,
     depths : list
         List of depth measurements. Returned only if `return_depths=True`.
     """
-    # if not (section is None):
-    #     if issubclass(type(section), dm_section.BaseSection):
-    #         section_trace = section.trace
-    #     elif isinstance(section, np.ndarray):
-    #         section_trace = section
-    # else:
-    #     # create one by default based on the channelmask?
-    #     raise NotImplementedError()
-
-    # channelmask = np.array(channelmask.mask)
     if not (section is None):
         if issubclass(type(section), dm_section.BaseSection):
             section_trace = section.trace
@@ -1163,8 +1162,6 @@ def compute_channel_depth(channelmask, depth, section=None,
         raise ValueError(
             'Invalid argument to `depth_type` {}'.format(
                 str(depth_type)))
-
-    print(_channel_depth_list)
 
     _m, _s = np.mean(_channel_depth_list), np.std(_channel_depth_list)
     if return_depths:

--- a/docs/source/reference/plan/index.rst
+++ b/docs/source/reference/plan/index.rst
@@ -28,4 +28,6 @@ Functions
 	compute_shoreline_roughness
 	compute_shoreline_length
     compute_shoreline_distance
+    compute_channel_width
+	compute_channel_depth
 	shaw_opening_angle_method

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ xarray
 pooch
 numba
 h5netcdf
+h5py

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -431,7 +431,7 @@ class TestComputeChannelDepth:
                 section=self.sec)
 
     def test_bad_depth_type_arg(self):
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             m, s = plan.compute_channel_depth(
                 self.cm, self.golf['depth'][-1, :, :],
                 depth_type='nonsense', section=self.sec)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -411,7 +411,7 @@ class TestComputeChannelDepth:
         assert s1 == s2
         assert len(w) == 4
 
-    def test_depths_example(self):
+    def test_depths_example_thalweg(self):
         """Get mean and std from example."""
 
         m, s = plan.compute_channel_depth(
@@ -429,6 +429,12 @@ class TestComputeChannelDepth:
             m, s = plan.compute_channel_depth(
                 True, self.golf['depth'][-1, :, :],
                 section=self.sec)
+
+    def test_bad_depth_type_arg(self):
+        with pytest.raises(TypeError):
+            m, s = plan.compute_channel_depth(
+                self.cm, self.golf['depth'][-1, :, :],
+                depth_type='nonsense', section=self.sec)
 
     def test_no_section_make_default(self):
         with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Implement simple channel width and depth measurements. These metrics compute geometries of channels along a predefined section. For example, the widths:

![image](https://user-images.githubusercontent.com/8801322/124280633-89089c00-db0e-11eb-9bf9-4af969db86a8.png)
