### PR TITLE
Add Morphological Planform

### DIFF
--- a/deltametrics/_version.py
+++ b/deltametrics/_version.py
@@ -3,4 +3,4 @@ def __version__():
     """
     Private version declaration, gets assigned to dm.__version__ during import
     """
-    return '0.2.0'
+    return '0.3.0'

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -428,7 +428,8 @@ class BaseCube(abc.ABC):
                        vmax=self.varset[var].vmax)
         cb = plot.append_colorbar(im, ax)
         if colorbar_label:
-            _colorbar_label = self.varset[var].label if (colorbar_label is True) \
+            _colorbar_label = \
+                self.varset[var].label if (colorbar_label is True) \
                 else str(colorbar_label)  # use custom if passed
             cb.ax.set_ylabel(_colorbar_label, rotation=-90, va="bottom")
 
@@ -709,9 +710,8 @@ class StratigraphyCube(BaseCube):
             self._L, self._W = _elev.shape[1:]
             self._Z = np.tile(self.z, (self.W, self.L, 1)).T
 
-            _out = strat.compute_boxy_stratigraphy_coordinates(_elev,
-                                                               z=self.z,
-                                                            return_strata=True)
+            _out = strat.compute_boxy_stratigraphy_coordinates(
+                _elev, z=self.z, return_strata=True)
             self.strata_coords, self.data_coords, self.strata = _out
         else:
             raise TypeError('No other input types implemented yet.')

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -1296,7 +1296,7 @@ class ShorelineMask(BaseMask):
                 _eta, **kwargs)
 
             # get fields and compute the mask
-            _elevationmask = _MPM._elev_mask
+            _elevationmask = _MPM._elevation_mask
             _meanimage = _MPM._mean_image
 
             # compute the mask
@@ -1312,8 +1312,9 @@ class ShorelineMask(BaseMask):
                     _sea_angles = args[0]._sea_angles
                     _method = 'OAM'
                 elif isinstance(args[0], plan.MorphologicalPlanform):
-                    _elev_mask = args[0]._elev_mask
+                    _elev_mask = args[0]._elevation_mask
                     _mean_image = args[0]._mean_image
+                    _method = 'MPM'
         if len(args) >= 3:
             _method = args[2]
             if _method == 'OAM':
@@ -1391,7 +1392,7 @@ class ShorelineMask(BaseMask):
         topo_threshold : float, optional
             Threshold depth to use. Default is -0.5.
 
-        maxdisk : int, optional
+        max_disk : int, optional
             Defines the max disk size for the morphological element.
             Default is 3.
 
@@ -1401,7 +1402,12 @@ class ShorelineMask(BaseMask):
                 raise TypeError('Must be type MPM.')
             _mean_image = args[0]._mean_image
         elif len(args) == 2:
-            _mean_image = args[0]
+            if isinstance(args[0], plan.MorphologicalPlanform):
+                _mean_image = args[0]._mean_image
+            elif utils.is_ndarray_or_xarray(args[1]):
+                _mean_image = args[1]
+            else:
+                raise ValueError
         else:
             raise ValueError
 

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 from skimage import feature
 from skimage import morphology
 from skimage import measure
+from scipy.ndimage import binary_fill_holes
 
 import abc
 import warnings
@@ -1116,6 +1117,9 @@ class LandMask(BaseMask):
             self._mask = np.zeros(self._shape, dtype=bool)
         else:
             self._mask = (composite_array < self._contour_threshold)
+
+        # fill any holes in the mask
+        self._mask = binary_fill_holes(self._mask)
 
     @property
     def contour_threshold(self):

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -1170,7 +1170,7 @@ class ShorelineMask(BaseMask):
             _method = kwargs.pop('method')
             if _method == 'MPM':
                 _Planform = plan.MorphologicalPlanform(
-                    UnknownMask)
+                    UnknownMask, kwargs['max_disk'])
             else:
                 _Planform = plan.OpeningAnglePlanform.from_ElevationMask(
                     UnknownMask)

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -275,7 +275,7 @@ class ThresholdValueMask(BaseMask, abc.ABC):
         elif self._input_flag == 'mask':
             raise NotImplementedError(
                 'Cannot instantiate `ThresholdValueMask` or '
-                'andy subclasses from another mask.')
+                'any subclasses from another mask.')
         elif self._input_flag == 'array':
             _field = args[0]
         else:
@@ -289,6 +289,10 @@ class ThresholdValueMask(BaseMask, abc.ABC):
         """Generic property for ThresholdValueMask threshold.
         """
         return self._threshold
+
+    def _compute_mask(self):
+        """Provide abstract method."""
+        pass
 
 
 class ElevationMask(ThresholdValueMask):
@@ -961,12 +965,18 @@ class LandMask(BaseMask):
         else:
             raise TypeError
 
+        if 'contour_threshold' in kwargs:
+            _contour_threshold = kwargs.pop('contour_threshold')
+        else:
+            _contour_threshold = 75
+
         # set up the empty shoreline mask
-        _LM = LandMask(allow_empty=True)
+        _LM = LandMask(allow_empty=True, contour_threshold=_contour_threshold)
         _LM._set_shape_mask(_Planform.shape)
 
         # compute the mask
         _composite_array = _Planform.composite_array
+
         _LM._compute_mask(_composite_array, **kwargs)
         return _LM
 

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -463,9 +463,9 @@ class MorphologicalPlanform(BasePlanform):
         return MorphologicalPlanform(_em, max_disk, **kwargs)
 
     @staticmethod
-    def from_mask(UnknownMask, maxdisk, **kwargs):
+    def from_mask(UnknownMask, max_disk, **kwargs):
         """Static method for creating a MorphologicalPlanform from a mask."""
-        return MorphologicalPlanform(UnknownMask, maxdisk, **kwargs)
+        return MorphologicalPlanform(UnknownMask, max_disk, **kwargs)
 
     def __init__(self, *args, **kwargs):
         """Initialize the MP.
@@ -531,7 +531,7 @@ class MorphologicalPlanform(BasePlanform):
             self._elevation_mask, biggestdisk=self._max_disk)
 
         # assign arrays to object
-        self._mean_image = mean_image
+        self._mean_image = np.ones_like(mean_image) - mean_image
         self._all_images = all_images
 
     @property
@@ -1100,8 +1100,8 @@ def _custom_closing(img, disksize):
     """Private function for the binary closing."""
     _changed = np.infty
     disk = morphology.disk(disksize)
-    _iter = 0  # count number of closings
-    while (_changed != 0) and (_iter < 1000):
+    _iter = 0  # count number of closings, cap at 100
+    while (_changed != 0) and (_iter < 100):
         _iter += 1
         _newimg = morphology.binary_closing(img, selem=disk)
         _changed = np.sum(_newimg.astype(float)-img.astype(float))

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -63,10 +63,10 @@ class BasePlanform(abc.ABC):
         self.planform_type = planform_type
         self._name = name
 
-        if len(args) != 1:
-            raise ValueError('Expected single positional argument to \
-                             %s instantiation.'
-                             % type(self))
+        # if len(args) != 1:
+        #     raise ValueError('Expected single positional argument to \
+        #                      %s instantiation.'
+        #                      % type(self))
 
         if issubclass(type(args[0]), cube.BaseCube):
             self.connect(args[0])
@@ -417,7 +417,7 @@ class MorphologicalPlanform(BasePlanform):
     """
 
     @staticmethod
-    def from_elevation_data(elevation_data, **kwargs):
+    def from_elevation_data(elevation_data, max_disk, **kwargs):
         """Create a `MorphologicalPlanform` from elevation data.
 
         Creates an ElevationMask from the input elevation array that is used
@@ -439,6 +439,9 @@ class MorphologicalPlanform(BasePlanform):
             The elevation data to create the `ElevationMask` that is in
             turn used to create the `MorphologicalPlanform`.
 
+        max_disk : int
+            Maximum disk size to use for the morphological operations.
+
         Examples
         --------
 
@@ -448,14 +451,15 @@ class MorphologicalPlanform(BasePlanform):
 
             >>> MP = dm.plan.MorphologicalPlanform.from_elevation_data(
             ...     golfcube['eta'][-1, :, :],
-            ...     elevation_threshold=0)
+            ...     elevation_threshold=0,
+                    max_disk=3)
         """
         # make a temporary mask
         _em = mask.ElevationMask(
             elevation_data, **kwargs)
 
         # compute from __init__ pathway
-        return MorphologicalPlanform(_em, **kwargs)
+        return MorphologicalPlanform(_em, max_disk, **kwargs)
 
     @staticmethod
     def from_mask(UnknownMask, **kwargs):
@@ -494,7 +498,7 @@ class MorphologicalPlanform(BasePlanform):
                 raise ValueError(
                     'Expected at least 1 input, got 0.')
         # assign first argument to attribute of self
-        if isinstance(args[0], mask.ChannelMask):
+        if isinstance(args[0], mask.BaseMask):
             self._elevation_mask = args[0]
         elif utils.is_ndarray_or_xarray(args[0]):
             self._elevation_mask = args[0]
@@ -1137,7 +1141,7 @@ def morphological_closing_method(elevationmask, biggestdisk=None):
         axis. This approximates the `sea_angles` attribute of the OAM method.
     """
     # coerce input image into 2-d ndarray
-    if isinstance(elevationmask, mask.ChannelMask):
+    if isinstance(elevationmask, mask.BaseMask):
         emsk = np.array(elevationmask.mask)
     elif utils.is_ndarray_or_xarray(elevationmask):
         emsk = np.array(elevationmask)

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -453,7 +453,7 @@ class MorphologicalPlanform(BasePlanform):
             >>> MP = dm.plan.MorphologicalPlanform.from_elevation_data(
             ...     golfcube['eta'][-1, :, :],
             ...     elevation_threshold=0,
-                    max_disk=3)
+            ...     max_disk=3)
         """
         # make a temporary mask
         _em = mask.ElevationMask(

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -457,6 +457,11 @@ class MorphologicalPlanform(BasePlanform):
         # compute from __init__ pathway
         return MorphologicalPlanform(_em, **kwargs)
 
+    @staticmethod
+    def from_mask(UnknownMask, **kwargs):
+        """Static method for creating a MorphologicalPlanform from a mask."""
+        return MorphologicalPlanform(UnknownMask, **kwargs)
+
     def __init__(self, *args, **kwargs):
         """Initialize the MP.
 

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -494,13 +494,13 @@ class MorphologicalPlanform(BasePlanform):
                 raise ValueError(
                     'Expected at least 1 input, got 0.')
         # assign first argument to attribute of self
-        if isinstance(args[0], mask.ChannelMask:
+        if isinstance(args[0], mask.ChannelMask):
             self._elevation_mask = args[0]
         elif utils.is_ndarray_or_xarray(args[0]):
             self._elevation_mask = args[0]
         else:
             raise TypeError(
-                'Type of first argument is unrecognized or unsupported'.)
+                'Type of first argument is unrecognized or unsupported')
         # see if the inlet width is provided, if not see if cube is avail
         if (len(args) > 1):
             if isinstance(args[1], (int, float)):

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1103,7 +1103,6 @@ def _custom_closing(img, disksize):
     _iter = 0  # count number of closings
     while (_changed != 0) and (_iter < 1000):
         _iter += 1
-        print(_iter)
         _newimg = morphology.binary_closing(img, selem=disk)
         _changed = np.sum(_newimg.astype(float)-img.astype(float))
         _closed = _newimg

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -1,6 +1,8 @@
 import numpy as np
 import xarray as xr
 from scipy import optimize
+import time
+import datetime
 
 from numba import njit
 
@@ -538,3 +540,30 @@ def _points_in_polygon(points, polygon):
         inside[i] = _point_in_polygon(points[i, 0], points[i, 1], polygon)
 
     return inside
+
+
+def runtime_from_log(logname):
+    """Calculate the model runtime from the logfile.
+
+    Uses the timestamps in the logfile to compute the model runtime.
+
+    Parameters
+    ----------
+    logname : :obj:`str:`
+        Path to the model logfile that you wish to get the runtime for
+
+    Returns
+    -------
+    runtime : :obj:`float`
+        Float of the model runtime in seconds.
+    """
+    with open(logname) as f:
+        lines = f.readlines()
+        start = lines[0][:19]
+        t_start = time.strptime(start, '%Y-%m-%d %H:%M:%S')
+        t1 = time.mktime(t_start)
+        fin = lines[-1][:19]
+        t_end = time.strptime(fin, '%Y-%m-%d %H:%M:%S')
+        t2 = time.mktime(t_end)
+        te = datetime.timedelta(seconds=t2-t1)
+    return te.total_seconds()

--- a/docs/source/guides/examples/index.rst
+++ b/docs/source/guides/examples/index.rst
@@ -13,3 +13,4 @@ Examples of how to do various tasks and visualizations in DeltaMetrics.
    plot/show_section
    computations/preserved_velocities
    computations/comparing_speeds_of_stratigraphy_access
+   planforms/planform_intro

--- a/docs/source/guides/examples/planforms/planform_intro.rst
+++ b/docs/source/guides/examples/planforms/planform_intro.rst
@@ -1,0 +1,30 @@
+Introduction to Planform Objects
+================================
+
+Multiple definitions of the delta planform are supported.
+These planform objects can be used as starting points for binary mask computation.
+If not specified explicitly, they are often implicitly part of binary mask creation.
+
+Below we demonstrate instantiation of both the :obj:`~deltametrics.plan.OpeningAnglePlanform` and the :obj:`~deltametrics.plan.MorphologicalPlanform` objects.
+
+The OpeningAnglePlanform
+------------------------
+
+This planform object is based around the Opening Angle Method [1]_.
+
+.. todo::
+
+  Add example here
+
+.. [1] Shaw, J. B., Wolinsky, M. A., Paola, C., & Voller, V. R. (2008). An image‐based method for shoreline mapping on complex coasts. Geophysical Research Letters, 35(12).
+
+The MorphologicalPlanform
+-------------------------
+
+This planform object uses mathematical morphology to identify the delta planform, inspired by Geleynse et al (2012) [2]_.
+
+.. todo::
+
+  Add example here
+
+.. [2] Geleynse, N., Voller, V. R., Paola, C., & Ganti, V. (2012). Characterization of river delta shorelines. Geophysical research letters, 39(17).

--- a/docs/source/guides/examples/planforms/planform_intro.rst
+++ b/docs/source/guides/examples/planforms/planform_intro.rst
@@ -7,14 +7,58 @@ If not specified explicitly, they are often implicitly part of binary mask creat
 
 Below we demonstrate instantiation of both the :obj:`~deltametrics.plan.OpeningAnglePlanform` and the :obj:`~deltametrics.plan.MorphologicalPlanform` objects.
 
+For each we start with the same example dataset, and use the elevation data at the end of the simulation.
+
+.. plot::
+    :context: reset
+    :include-source:
+
+    golfcube = dm.sample_data.golf()
+
+    plt.imshow(golfcube['eta'][-1, :, :])
+    plt.colorbar()
+    plt.title('Final Elevation Data')
+    plt.show()
+
+.. plot::
+    :context:
+
+    plt.close()
+
 The OpeningAnglePlanform
 ------------------------
 
 This planform object is based around the Opening Angle Method [1]_.
 
+The `OpeningAnglePlanform` can be created directly from elevation data:
+
+.. plot::
+    :context:
+    :include-source:
+
+    golfcube = dm.sample_data.golf()
+    OAP = dm.plan.OpeningAnglePlanform.from_elevation_data(
+      golfcube['eta'][-1, :, :], elevation_threshold=0)
+
+All planforms have a `composite_array` attribute from which a contour is extracted when defining the shoreline.
+In the case of the `OpeningAnglePlanform`, the `composite_array` is the "sea angles" array from the Opening Angle Method.
+
+.. plot::
+    :context:
+    :include-source:
+
+    plt.imshow(OAP.composite_array)
+    plt.colorbar()
+    plt.show()
+
+.. plot::
+    :context:
+
+    plt.close()
+
 .. todo::
 
-  Add example here
+  Embellish the example
 
 .. [1] Shaw, J. B., Wolinsky, M. A., Paola, C., & Voller, V. R. (2008). An image‐based method for shoreline mapping on complex coasts. Geophysical Research Letters, 35(12).
 
@@ -23,8 +67,74 @@ The MorphologicalPlanform
 
 This planform object uses mathematical morphology to identify the delta planform, inspired by Geleynse et al (2012) [2]_.
 
+The `MorphologicalPlanform` can also be created directly from elevation data:
+
+.. plot::
+    :context:
+    :include-source:
+
+    MP = dm.plan.MorphologicalPlanform.from_elevation_data(
+      golfcube['eta'][-1, :, :], elevation_threshold=0, max_disk=5)
+
+In this case, the `composite_array` attribute of the planform represents the inverse of the average pixel value when different sized disks are used to perform the binary closing on the elevation data.
+
+.. plot::
+    :context:
+    :include-source:
+
+    plt.imshow(MP.composite_array)
+    plt.colorbar()
+    plt.show()
+
+.. plot::
+    :context:
+
+    plt.close()
+
 .. todo::
 
-  Add example here
+  Embellish example
 
 .. [2] Geleynse, N., Voller, V. R., Paola, C., & Ganti, V. (2012). Characterization of river delta shorelines. Geophysical research letters, 39(17).
+
+Mask Extraction
+---------------
+
+These planform objects can be used to extract shoreline masks as well as land masks.
+The masking API accepts either planform object as an input, making it easy to swap one planform for the other in a masking workflow.
+
+As an example, we will extract a shoreline from both planforms shown above.
+Of course the two methods are different, so the shorelines identified will also be different.
+
+.. plot::
+    :context:
+    :include-source:
+
+    SM_from_OAM = dm.mask.ShorelineMask.from_Planform(
+      OAP, contour_threshold=75)
+
+    SM_from_MPM = dm.mask.ShorelineMask.from_Planform(
+      MP, contour_threshold=0.75)
+
+    fig, ax = plt.subplots(1, 3, figsize=(10, 5), dpi=300)
+
+    ax[0].imshow(SM_from_OAM.mask, interpolation=None)
+    ax[0].set_title('Shoreline from OAM')
+
+    ax[1].imshow(SM_from_MPM.mask, interpolation=None)
+    ax[1].set_title('Shoreline from MPM')
+
+    d_plot = ax[2].imshow(
+      SM_from_OAM.mask.astype(float) - SM_from_MPM.mask.astype(float),
+      interpolation=None, cmap='bone')
+    ax[2].set_title('OAM shoreline - MPM shoreline')
+    plt.colorbar(d_plot, ax=ax[2], fraction=0.05)
+
+    plt.tight_layout()
+    plt.show()
+
+Both methods require the user to set a "contour threshold" value when extracting the shoreline.
+The shoreline ends up being a contour extracted at this value from the planform `composite_array`.
+
+The OAM method is relatively insensitive to the value of this threshold, whereas the MPM method can be more sensitive, depending on the range of disk sizes used.
+Overall though, this example shows that the two methods produce roughly similar shorelines, and the syntax of the function calls to produce the planforms and the shoreline masks is more similar than it is different.

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -2,9 +2,7 @@
 User Guide
 **********
 
-This documentation provides a
-
-
+This documentation provides some "workflow" examples as well as some explanations and background about the various methods available in DeltaMetrics.
 
 
 Examples
@@ -16,8 +14,6 @@ We maintain a library of "workflow" examples, which show how to do common, inter
   :maxdepth: 2
 
   examples/index
-
-
 
 
 Setting up your coding environment
@@ -482,7 +478,7 @@ See the :doc:`reference page for each mask type </reference/mask/index>` if you 
 
 .. plot::
     :context: reset
-    
+
     import matplotlib.pyplot as plt
     import matplotlib.gridspec as gs
     import numpy as np

--- a/docs/source/reference/mask/lexicon.rst
+++ b/docs/source/reference/mask/lexicon.rst
@@ -18,8 +18,8 @@ For example:
     ...     golfcube['eta'][-1, :, :],
     ...     elevation_threshold=0)
 
-    >>> lm = dm.mask.LandMask.from_OAP(OAP)
-    >>> sm = dm.mask.ShorelineMask.from_OAP(OAP)
+    >>> lm = dm.mask.LandMask.from_Planform(OAP)
+    >>> sm = dm.mask.ShorelineMask.from_Planform(OAP)
 
     >>> fig, ax = plt.subplots(2, 2)
     >>> golfcube.show_plan('eta', t=-1, ax=ax[0, 0])

--- a/docs/source/reference/plan/index.rst
+++ b/docs/source/reference/plan/index.rst
@@ -6,7 +6,7 @@ Planview operations
 
 The package makes available functions relating to planview operations on data.
 
-The functions are defined in ``deltametrics.plan``. 
+The functions are defined in ``deltametrics.plan``.
 
 
 Planform types
@@ -14,20 +14,22 @@ Planform types
 
 .. currentmodule:: deltametrics.plan
 
-.. autosummary:: 
+.. autosummary::
     :toctree: ../../_autosummary
 
     OpeningAnglePlanform
+		MorphologicalPlanform
 
 Functions
 =========
 
-.. autosummary:: 
+.. autosummary::
 	:toctree: ../../_autosummary
 
 	compute_shoreline_roughness
 	compute_shoreline_length
-    compute_shoreline_distance
-    compute_channel_width
+  compute_shoreline_distance
+  compute_channel_width
 	compute_channel_depth
 	shaw_opening_angle_method
+	morphological_closing_method

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -244,7 +244,7 @@ class TestShorelineMask:
         # make assertions
         assert shoremask._input_flag == 'array'
         assert shoremask.mask_type == 'shoreline'
-        assert shoremask.angle_threshold > 0
+        assert shoremask.contour_threshold > 0
         assert shoremask._mask.dtype == bool
         assert isinstance(shoremask._mask, np.ndarray)
 
@@ -257,7 +257,7 @@ class TestShorelineMask:
         # make assertions
         assert shoremask._input_flag == 'cube'
         assert shoremask.mask_type == 'shoreline'
-        assert shoremask.angle_threshold > 0
+        assert shoremask.contour_threshold > 0
         assert shoremask._mask.dtype == bool
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=True,
@@ -269,7 +269,7 @@ class TestShorelineMask:
         # make assertions
         assert shoremask._input_flag == 'cube'
         assert shoremask.mask_type == 'shoreline'
-        assert shoremask.angle_threshold > 0
+        assert shoremask.contour_threshold > 0
         assert shoremask._mask.dtype == bool
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=True,
@@ -281,7 +281,7 @@ class TestShorelineMask:
         # make assertions
         assert shoremask._input_flag == 'mask'
         assert shoremask.mask_type == 'shoreline'
-        assert shoremask.angle_threshold > 0
+        assert shoremask.contour_threshold > 0
         assert shoremask._mask.dtype == bool
 
     def test_angle_threshold(self):
@@ -293,9 +293,9 @@ class TestShorelineMask:
         shoremask = mask.ShorelineMask(
             rcm8cube['eta'][-1, :, :],
             elevation_threshold=0,
-            angle_threshold=45)
+            contour_threshold=45)
         # make assertions
-        assert shoremask.angle_threshold == 45
+        assert shoremask.contour_threshold == 45
         assert not np.all(shoremask_default == shoremask)
 
     def test_submergedLand(self):
@@ -315,12 +315,12 @@ class TestShorelineMask:
         shoremask = mask.ShorelineMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        mfOAP = mask.ShorelineMask.from_OAP(_OAP_0)
+        mfOAP = mask.ShorelineMask.from_Planform(_OAP_0)
 
         shoremask_05 = mask.ShorelineMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0.5)
-        mfOAP_05 = mask.ShorelineMask.from_OAP(_OAP_05)
+        mfOAP_05 = mask.ShorelineMask.from_Planform(_OAP_05)
 
         assert np.all(shoremask._mask == mfOAP._mask)
         assert np.all(shoremask_05._mask == mfOAP_05._mask)
@@ -690,7 +690,7 @@ class TestLandMask:
         # make assertions
         assert landmask._input_flag == 'array'
         assert landmask.mask_type == 'land'
-        assert landmask.angle_threshold > 0
+        assert landmask.contour_threshold > 0
         assert landmask._mask.dtype == bool
 
     def test_default_vals_array_needs_elevation_threshold(self):
@@ -708,7 +708,7 @@ class TestLandMask:
         # make assertions
         assert landmask._input_flag == 'cube'
         assert landmask.mask_type == 'land'
-        assert landmask.angle_threshold > 0
+        assert landmask.contour_threshold > 0
         assert landmask._mask.dtype == bool
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=True,
@@ -720,7 +720,7 @@ class TestLandMask:
         # make assertions
         assert landmask._input_flag == 'cube'
         assert landmask.mask_type == 'land'
-        assert landmask.angle_threshold > 0
+        assert landmask.contour_threshold > 0
         assert landmask._mask.dtype == bool
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=True,
@@ -732,7 +732,7 @@ class TestLandMask:
         # make assertions
         assert landmask._input_flag == 'mask'
         assert landmask.mask_type == 'land'
-        assert landmask.angle_threshold > 0
+        assert landmask.contour_threshold > 0
         assert landmask._mask.dtype == bool
 
     def test_angle_threshold(self):
@@ -747,9 +747,9 @@ class TestLandMask:
         landmask = mask.LandMask(
             rcm8cube['eta'][-1, :, :],
             elevation_threshold=0,
-            angle_threshold=45)
+            contour_threshold=45)
         # make assertions
-        assert landmask.angle_threshold == 45
+        assert landmask.contour_threshold == 45
         assert not np.all(landmask_default == landmask)
 
     def test_submergedLand(self):
@@ -769,12 +769,12 @@ class TestLandMask:
         landmask = mask.LandMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        mfOAP = mask.LandMask.from_OAP(_OAP_0)
+        mfOAP = mask.LandMask.from_Planform(_OAP_0)
 
         landmask_05 = mask.LandMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0.5)
-        mfOAP_05 = mask.LandMask.from_OAP(_OAP_05)
+        mfOAP_05 = mask.LandMask.from_Planform(_OAP_05)
 
         assert np.all(landmask._mask == mfOAP._mask)
         assert np.all(landmask_05._mask == mfOAP_05._mask)
@@ -872,7 +872,7 @@ class TestWetMask:
         wetmask = mask.WetMask(
             rcm8cube['eta'][-1, :, :],
             elevation_threshold=0,
-            angle_threshold=45)
+            contour_threshold=45)
         # make assertions
         assert not np.all(wetmask_default == wetmask)
         assert np.sum(wetmask.integer_mask) < np.sum(wetmask_default.integer_mask)
@@ -895,13 +895,13 @@ class TestWetMask:
         landmask = mask.LandMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        mfOAP = mask.LandMask.from_OAP(_OAP_0)
+        mfOAP = mask.LandMask.from_Planform(_OAP_0)
 
         # create two with diff elevation threshold
         landmask_05 = mask.LandMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0.5)
-        mfOAP_05 = mask.LandMask.from_OAP(_OAP_05)
+        mfOAP_05 = mask.LandMask.from_Planform(_OAP_05)
 
         assert np.all(landmask._mask == mfOAP._mask)
         assert np.all(landmask_05._mask == mfOAP_05._mask)
@@ -1017,7 +1017,7 @@ class TestChannelMask:
             rcm8cube['velocity'][-1, :, :],
             elevation_threshold=0,
             flow_threshold=0.5,
-            angle_threshold=45)
+            contour_threshold=45)
         # make assertions
         assert not np.all(channelmask_default == channelmask)
         assert np.sum(channelmask.integer_mask) < np.sum(channelmask_default.integer_mask)
@@ -1036,8 +1036,8 @@ class TestChannelMask:
 
     def test_static_from_OAP_not_implemented(self):
         with pytest.raises(NotImplementedError,
-                           match=r'`from_OAP` is not defined .*'):
-            _ = mask.ChannelMask.from_OAP(_OAP_0)
+                           match=r'`from_Planform` is not defined .*'):
+            _ = mask.ChannelMask.from_Planform(_OAP_0)
 
     def test_static_from_OAP_and_FlowMask(self):
         """
@@ -1053,7 +1053,8 @@ class TestChannelMask:
         flowmask_03 = mask.FlowMask(
             golfcube['velocity'][-1, :, :],
             flow_threshold=0.3)
-        mfOAP_03 = mask.ChannelMask.from_OAP_and_FlowMask(_OAP_0, flowmask_03)
+        mfOAP_03 = mask.ChannelMask.from_Planform_and_FlowMask(
+            _OAP_0, flowmask_03)
 
         channelmask_06 = mask.ChannelMask(
             golfcube['eta'][-1, :, :],
@@ -1063,7 +1064,8 @@ class TestChannelMask:
         flowmask_06 = mask.FlowMask(
             golfcube['velocity'][-1, :, :],
             flow_threshold=0.6)
-        mfOAP_06 = mask.ChannelMask.from_OAP_and_FlowMask(_OAP_05, flowmask_06)
+        mfOAP_06 = mask.ChannelMask.from_Planform_and_FlowMask(
+            _OAP_05, flowmask_06)
 
         assert np.all(channelmask_03._mask == mfOAP_03._mask)
         assert np.all(channelmask_06._mask == mfOAP_06._mask)
@@ -1095,7 +1097,7 @@ class TestChannelMask:
         flowmask = mask.FlowMask(
             golfcube['velocity'][-1, :, :],
             flow_threshold=0.3)
-        landmask = mask.LandMask.from_OAP(_OAP_0)
+        landmask = mask.LandMask.from_Planform(_OAP_0)
 
         mfem = mask.ChannelMask.from_mask(landmask, flowmask)
         mfem2 = mask.ChannelMask.from_mask(flowmask, landmask)
@@ -1193,7 +1195,7 @@ class TestEdgeMask:
         edgemask = mask.EdgeMask(
             rcm8cube['eta'][-1, :, :],
             elevation_threshold=0,
-            angle_threshold=45)
+            contour_threshold=45)
         # make assertions
         assert not np.all(edgemask_default == edgemask)
         assert np.sum(edgemask.integer_mask) != np.sum(edgemask_default.integer_mask)
@@ -1213,12 +1215,12 @@ class TestEdgeMask:
         edgemask_0 = mask.EdgeMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        mfOAP_0 = mask.EdgeMask.from_OAP(_OAP_0)
+        mfOAP_0 = mask.EdgeMask.from_Planform(_OAP_0)
 
         edgemask_05 = mask.EdgeMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0.5)
-        mfOAP_05 = mask.EdgeMask.from_OAP(_OAP_05)
+        mfOAP_05 = mask.EdgeMask.from_Planform(_OAP_05)
 
         assert np.all(edgemask_0._mask == mfOAP_0._mask)
         assert np.all(edgemask_05._mask == mfOAP_05._mask)
@@ -1236,7 +1238,7 @@ class TestEdgeMask:
         wetmask_0 = mask.WetMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        mfOAP_0 = mask.EdgeMask.from_OAP_and_WetMask(_OAP_0, wetmask_0)
+        mfOAP_0 = mask.EdgeMask.from_Planform_and_WetMask(_OAP_0, wetmask_0)
 
         assert np.all(edgemask_0._mask == mfOAP_0._mask)
 
@@ -1244,8 +1246,8 @@ class TestEdgeMask:
         edgemask_comp = mask.EdgeMask(
             golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        landmask = mask.LandMask.from_OAP(_OAP_0)
-        wetmask = mask.WetMask.from_OAP(_OAP_0)
+        landmask = mask.LandMask.from_Planform(_OAP_0)
+        wetmask = mask.WetMask.from_Planform(_OAP_0)
 
         mfem = mask.EdgeMask.from_mask(landmask, wetmask)
         mfem2 = mask.EdgeMask.from_mask(wetmask, landmask)
@@ -1333,7 +1335,7 @@ class TestCenterlineMask:
             rcm8cube['velocity'][-1, :, :],
             elevation_threshold=0,
             flow_threshold=0.5,
-            angle_threshold=45)
+            contour_threshold=45)
         # make assertions
         assert not np.all(centerlinemask_default == centerlinemask)
         # should be fewer pixels since channels are shorter
@@ -1354,8 +1356,8 @@ class TestCenterlineMask:
 
     def test_static_from_OAP_not_implemented(self):
         with pytest.raises(NotImplementedError,
-                           match=r'`from_OAP` is not defined .*'):
-            _ = mask.CenterlineMask.from_OAP(_OAP_0)
+                           match=r'`from_Planform` is not defined .*'):
+            _ = mask.CenterlineMask.from_Planform(_OAP_0)
 
     def test_static_from_OAP_and_FlowMask(self):
         """
@@ -1371,7 +1373,8 @@ class TestCenterlineMask:
         flowmask_03 = mask.FlowMask(
             golfcube['velocity'][-1, :, :],
             flow_threshold=0.3)
-        mfOAP_03 = mask.CenterlineMask.from_OAP_and_FlowMask(_OAP_0, flowmask_03)
+        mfOAP_03 = mask.CenterlineMask.from_Planform_and_FlowMask(
+            _OAP_0, flowmask_03)
 
         centerlinemask_06 = mask.CenterlineMask(
             golfcube['eta'][-1, :, :],
@@ -1381,7 +1384,8 @@ class TestCenterlineMask:
         flowmask_06 = mask.FlowMask(
             golfcube['velocity'][-1, :, :],
             flow_threshold=0.6)
-        mfOAP_06 = mask.CenterlineMask.from_OAP_and_FlowMask(_OAP_05, flowmask_06)
+        mfOAP_06 = mask.CenterlineMask.from_Planform_and_FlowMask(
+            _OAP_05, flowmask_06)
 
         assert np.all(centerlinemask_03._mask == mfOAP_03._mask)
         assert np.all(centerlinemask_06._mask == mfOAP_06._mask)
@@ -1428,7 +1432,7 @@ class TestCenterlineMask:
         flowmask = mask.FlowMask(
             golfcube['velocity'][-1, :, :],
             flow_threshold=0.3)
-        landmask = mask.LandMask.from_OAP(_OAP_0)
+        landmask = mask.LandMask.from_Planform(_OAP_0)
 
         mfem = mask.CenterlineMask.from_mask(landmask, flowmask)
         mfem2 = mask.CenterlineMask.from_mask(flowmask, landmask)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -351,6 +351,17 @@ class TestShorelineMask:
         assert np.all(shoremask._mask == mfem._mask)
         assert np.sum(shoremask_05.integer_mask) < np.sum(shoremask.integer_mask)
 
+    def test_static_from_masks_EM_MPM(self):
+        shoremask = mask.ShorelineMask(
+            golfcube['eta'][-1, :, :],
+            elevation_threshold=0,
+            contour_threshold=0.5, method='MPM', max_disk=12)
+        mfem = mask.ShorelineMask.from_masks(
+            self._ElevationMask, method='MPM', contour_threshold=0.5,
+            max_disk=12)
+
+        assert np.all(shoremask._mask == mfem._mask)
+
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -809,14 +809,14 @@ class TestLandMask:
         with pytest.raises(TypeError):
             mask.LandMask.from_mask('invalid input')
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='MPM method seems to be buggy...')
-    def test_static_from_mask_MPM(self):
-        mfem = mask.LandMask.from_mask(
-            self._ElevationMask, method='MPM',
-            maxdisk=2, contour_threshold=0.5)
-
-        assert mfem.shape == self._ElevationMask.shape
+    # @pytest.mark.xfail(raises=NotImplementedError, strict=True,
+    #                    reason='MPM method seems to be buggy...')
+    # def test_static_from_mask_MPM(self):
+    #     mfem = mask.LandMask.from_mask(
+    #         self._ElevationMask, method='MPM',
+    #         maxdisk=2, contour_threshold=0.5)
+    #
+    #     assert mfem.shape == self._ElevationMask.shape
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=True,
                        reason='Have not implemented pathway.')

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -138,9 +138,39 @@ class TestMorphologicalPlanform:
         mpm = plan.MorphologicalPlanform.from_elevation_data(
             self.golfcube['eta'][-1, :, :],
             elevation_threshold=0,
-            max_disk=2
-        )
-        import pdb; pdb.set_trace()
+            max_disk=2)
+        assert mpm.planform_type == 'morphological method'
+        assert mpm._mean_image.shape == (100, 200)
+        assert mpm._all_images.shape == (3, 100, 200)
+        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._all_images, np.ndarray)
+
+    def test_static_from_mask(self):
+        mpm = plan.MorphologicalPlanform.from_mask(
+            self.simple_land, 2)
+        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._all_images, np.ndarray)
+        assert mpm._mean_image.shape == self.simple_land.shape
+        assert len(mpm._all_images.shape) == 3
+        assert mpm._all_images.shape[0] == 3
+
+    def test_static_from_mask_negative_disk(self):
+        mpm = plan.MorphologicalPlanform.from_mask(
+            self.simple_land, -2)
+        assert isinstance(mpm.mean_image, np.ndarray)
+        assert isinstance(mpm.all_images, np.ndarray)
+        assert mpm.mean_image.shape == self.simple_land.shape
+        assert len(mpm.all_images.shape) == 3
+        assert mpm.all_images.shape[0] == 2
+        assert np.all(mpm.composite_array == mpm.mean_image)
+
+    def test_empty_error(self):
+        with pytest.raises(ValueError):
+            plan.MorphologicalPlanform()
+
+    def test_bad_type(self):
+        with pytest.raises(TypeError):
+            plan.MorphologicalPlanform('invalid string')
 
 
 class TestShawOpeningAngleMethod:

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -95,6 +95,53 @@ class TestOpeningAnglePlanform:
         #   this example, but I did verify it is actually be passed to the
         #   function.
 
+    def test_notcube_error(self):
+        with pytest.raises(TypeError):
+            plan.OpeningAnglePlanform(self.golfcube['eta'][-1, :, :].data)
+
+
+class TestMorphologicalPlanform:
+
+    simple_land = simple_land
+    golf_path = _get_golf_path()
+    golfcube = cube.DataCube(golf_path)
+
+    def test_defaults_array_int(self):
+        mpm = plan.MorphologicalPlanform(self.simple_land.astype(int), 2)
+        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._all_images, np.ndarray)
+        assert mpm._mean_image.shape == self.simple_land.shape
+        assert len(mpm._all_images.shape) == 3
+        assert mpm._all_images.shape[0] == 3
+
+    def test_defaults_array_bool(self):
+        mpm = plan.MorphologicalPlanform(self.simple_land.astype(bool), 2)
+        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._all_images, np.ndarray)
+        assert mpm._mean_image.shape == self.simple_land.shape
+        assert len(mpm._all_images.shape) == 3
+        assert mpm._all_images.shape[0] == 3
+
+    def test_defaults_array_float(self):
+        mpm = plan.MorphologicalPlanform(self.simple_land.astype(float), 2.0)
+        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._all_images, np.ndarray)
+        assert mpm._mean_image.shape == self.simple_land.shape
+        assert len(mpm._all_images.shape) == 3
+        assert mpm._all_images.shape[0] == 3
+
+    def test_invalid_disk_arg(self):
+        with pytest.raises(TypeError):
+            plan.MorphologicalPlanform(self.simple_land.astype(int), 'bad')
+
+    def test_defaults_static_from_elevation_data(self):
+        mpm = plan.MorphologicalPlanform.from_elevation_data(
+            self.golfcube['eta'][-1, :, :],
+            elevation_threshold=0,
+            max_disk=2
+        )
+        import pdb; pdb.set_trace()
+
 
 class TestShawOpeningAngleMethod:
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pytest
 
+import os
 import numpy as np
 
 from deltametrics import utils
@@ -129,7 +130,7 @@ def test_exponential_fit():
     assert pytest.approx(yfit == np.array([10.02900253, 4.85696353,
                                            2.22612537, 0.88790858]))
     assert pytest.approx(popts == np.array([10.02900253, -0.49751195,
-                                            0.67596451]))      
+                                            0.67596451]))
     assert pytest.approx(cov == np.array([[0.0841566, 0.04554967, 0.01139969],
                                           [0.04554967, 0.59895713, 0.08422946],
                                           [0.01139969, 0.08422946,
@@ -203,3 +204,17 @@ def test_format_table_float():
     _val = int(5.2)
     _fnum = utils.format_table(_val)
     assert _fnum == '5'
+
+
+@pytest.mark.xfail(raises=ImportError,
+                   reason='pyDeltaRCM is not a required dependency')
+def test_time_from_log(tmp_path):
+    """Generate run+logfile and then read runtime from it."""
+    from pyDeltaRCM.model import DeltaModel
+    delta = DeltaModel(out_dir=str(tmp_path))  # init delta to make log file
+    delta.finalize()  # finalize and end log file
+    log_path = os.path.join(tmp_path, os.listdir(tmp_path)[0])  # path to log
+    elapsed_time = utils.runtime_from_log(log_path)
+    # elapsed time should exceed 0, but exact time will vary
+    assert isinstance(elapsed_time, float)
+    assert elapsed_time > 0


### PR DESCRIPTION
This PR accomplishes the following:

1. Add an alternative `MorphologicalPlanform` based on a mathematical morphology method similar to the one described in [Geleynse et al 2012](https://doi.org/10.1029/2012GL052845)
2. Make the masking classes and methods more flexible to handle both the new "MPM" (morphological planform method) and existing "OAM" methodologies -- with the default behavior falling back on the OAM

The new `MorphologicalPlanform` class has been created, and the masking operations (and related unit tests) have been modified to allow the existing unit tests to pass, ensuring that the pre-existing OAM functionality has not been altered.

Of note, the `angle_threshold` has been generalized to a `contour_threshold` as this is more generic. For the OAM we use an angle threshold, but for the new MPM, this threshold is a value between 0 and 1. Similarly, the contour picking used for the shoreline extraction is based on an attribute `composite_array` that is just an alias to another field (for the OAM it is an alias for `sea_angles`). This is to just create a general and consistent name for the masking functions to refer to. 

Added an example of working with the two planform objects to the documentation, and included the shoreline extraction and a quick comparison. The two methods look roughly similar, of course the value used to pick the shoreline contour does matter, as does the "max disk" parameter used to control the range of disk sizes used for the morphological closing.

![image](https://user-images.githubusercontent.com/1770513/126487761-2ef53d70-27a1-461d-8804-b10a23ceb7e8.png)


I think the code could probably be made cleaner / more elegant, however this works and has some minimal documentation. At some point we probably need to revisit the entirety of the `deltametrics` codebase one file at a time to try and refactor things and add documentation anyway...