### PR TITLE
Optional return of image for dm.plot.aerial_view()

### DIFF
--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -1,7 +1,6 @@
 import numpy as np
 
 import colorsys
-import copy
 
 import matplotlib
 import matplotlib.pyplot as plt

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import colorsys
+import copy
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -1093,7 +1094,7 @@ def show_histograms(*args, sets=None, ax=None, **kwargs):
 
 
 def aerial_view(elevation_data, datum=0, ax=None, ticks=False,
-                colorbar_kw={}, **kwargs):
+                colorbar_kw={}, return_im=False, **kwargs):
     """Show an aerial plot of an elevation dataset.
 
     See also: implementation wrapper for a cube.
@@ -1118,6 +1119,9 @@ def aerial_view(elevation_data, datum=0, ax=None, ticks=False,
     colorbar_kw
         Dictionary of keyword args passed to :func:`append_colorbar`.
 
+    return_im : bool, optional
+        Returns the ``plt.imshow()`` image object if True. Default is False.
+
     **kwargs
         Optionally, arguments accepted by :func:`cartographic_colormap`, or
         `imshow`.
@@ -1126,6 +1130,9 @@ def aerial_view(elevation_data, datum=0, ax=None, ticks=False,
     -------
     colorbar
         Colorbar instance appended to the axes.
+
+    im : :obj:`~matplotlib.image.AxesImage` object, optional
+        Optional return of the image object itself if ``return_im`` is True
 
 
     Examples
@@ -1160,7 +1167,10 @@ def aerial_view(elevation_data, datum=0, ax=None, ticks=False,
         ax.set_xticks([], minor=[])
         ax.set_yticks([], minor=[])
 
-    return cb
+    if return_im is True:
+        return cb, im
+    else:
+        return cb
 
 
 def overlay_sparse_array(sparse_array, ax=None, cmap='Reds',


### PR DESCRIPTION
Minor change but a useful one I think. Was trying to make frames for an animation and wanted to use `dm.plot.aerial_view()`. It is faster to update the image drawn by `plt.imshow()` than it is to clear the axes and re-draw it for each frame. To do this the `aerial_view()` function needs to return the image it collects when calling `plt.imshow()` internally. This PR adds this as an optional return which can be obtained by toggling the optional keyword argument `return_im` to `True`. 

Because this addition is an optional one, existing behavior of the function is unchanged.

Rough example of my use-case:
```
for i in range(timesteps):

    # conditional for 1st timestep
    if i == 0:
        _, im = dm.plot.aerial_view(cube['eta'][i, ...], return_im=True)

    else:
        im.set_data(cube['eta'][i, ...])
        plt.draw()


    # save frame
    plt.savefig(...)
```