### PR TITLE
Temporary fix for show_plan method

### DIFF
--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -439,8 +439,15 @@ class BaseCube(abc.ABC):
         if title:
             ax.set_title(str(title))
 
-        ax.set_xlim(self.x[0], self.x[-1])
-        ax.set_ylim(self.y[0], self.y[-1])
+        # read from metadata if available
+        if self.meta is not None:
+            ax.set_ylim(self.x[0] / self.meta['dx'],
+                        self.x[-1] / self.meta['dx'])
+            ax.set_xlim(self.y[0] / self.meta['dx'],
+                        self.y[-1] / self.meta['dx'])
+        else:
+            ax.set_xlim(self.x[0], self.x[-1])
+            ax.set_ylim(self.y[0], self.y[-1])
 
     def show_section(self, *args, **kwargs):
         """Show a section.


### PR DESCRIPTION
Slightly modifies the `show_plan()` method to set x/y limits using metadata if it is available, otherwise previous behavior is retained at this time. Closes #71.

Although will have to be re-visited if the method is moved to `plan.py` and as the dimensions/coordinate handling changes.