### PR TITLE
Integrate xarray -- Part 1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install sphinx==2.0.1
+        pip install sphinx
         sudo apt update -y && sudo apt install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended dvipng
     - name: Install DeltaMetrics
       run: |

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -98,7 +98,7 @@ class BaseCube(abc.ABC):
 
     """
 
-    def __init__(self, data, read=[], varset=None):
+    def __init__(self, data, read=[], varset=None, coordinates={}):
         """Initialize the BaseCube.
 
         Parameters
@@ -122,7 +122,7 @@ class BaseCube(abc.ABC):
             # handle a path to netCDF file
             self._data_path = data
             self._connect_to_file(data_path=data)
-            self._read_meta_from_file()
+            self._read_meta_from_file(coordinates)
         elif type(data) is dict:
             # handle a dict, arrays set up already, make an io class to wrap it
             self._data_path = None
@@ -131,7 +131,7 @@ class BaseCube(abc.ABC):
             # handle initializing one cube type from another
             self._data_path = data.data_path
             self._dataio = data._dataio
-            self._read_meta_from_file()
+            self._read_meta_from_file(coordinates)
         else:
             raise TypeError('Invalid type for "data": %s' % type(data))
 
@@ -167,12 +167,28 @@ class BaseCube(abc.ABC):
             raise ValueError(
                 'Invalid file extension for "data_path": %s' % data_path)
 
-    def _read_meta_from_file(self):
+    def _read_meta_from_file(self, coordinates):
         """Read metadata information from variables in file.
 
         This method is used internally to gather some useful info for
         navigating the variable trees in the stored files.
+
+        Parameters
+        ----------
+        coordinates : :obj:`dict`
+
+            A dictionary describing *substitutions* to make for coordinates in
+            the underlying dataset with coordinates in DeltaMetrics.
+            Dictionary may be empty (default), in which case we connect the
+            `x` coordinate in DeltaMetrics to the `x` coordinate in the
+            underlying data file, and similarly for `y`. If the underlying
+            data file uses a different convention, for example `x` means
+            downstream rather than left-right, you can specify this by
+            passing a `key-value` pair describing the `value` in the
+            underlying data file that corresponds to the DeltaMetrics `key`.
         """
+        default_coordinates = {'x': 'x', 'y': 'y'}
+        default_coordinates.update(coordinates)
         self._coords = self._dataio.known_coords
         self._variables = self._dataio.known_variables
         # if x is 2-D then we assume x and y are mesh grid values
@@ -183,8 +199,8 @@ class BaseCube(abc.ABC):
             self._y = np.copy(self._Y[:, 0].squeeze())  # array of yval of cube
         # if x is 1-D we do mesh-gridding
         elif np.ndim(self._dataio['x']) == 1:
-            self._x = self._dataio['x']  # array of xval of cube
-            self._y = self._dataio['y']  # array of yval of cube
+            self._x = self._dataio[default_coordinates['x']]  # array of xval of cube
+            self._y = self._dataio[default_coordinates['y']]  # array of yval of cube
             self._X, self._Y = np.meshgrid(self._x, self._y)  # mesh grids x&y
 
     def read(self, variables):
@@ -418,6 +434,12 @@ class BaseCube(abc.ABC):
 
         _plan = self[var].data[t]  # REPLACE WITH OBJECT RETURNED FROM PLAN
 
+        _dx = self.x[1] - self.x[0]
+        _extent = [self._x[0] - (_dx/2),
+                   self._x[-1] - (_dx/2),
+                   self._y[0] - (_dx/2),
+                   self._y[-1] - (_dx/2)]
+
         if not ax:
             ax = plt.gca()
 
@@ -425,7 +447,8 @@ class BaseCube(abc.ABC):
                        cmap=self.varset[var].cmap,
                        norm=self.varset[var].norm,
                        vmin=self.varset[var].vmin,
-                       vmax=self.varset[var].vmax)
+                       vmax=self.varset[var].vmax,
+                       extent=_extent)
         cb = plot.append_colorbar(im, ax)
         if colorbar_label:
             _colorbar_label = \
@@ -438,9 +461,6 @@ class BaseCube(abc.ABC):
             ax.set_yticks([], minor=[])
         if title:
             ax.set_title(str(title))
-
-        ax.set_xlim(self.x[0], self.x[-1])
-        ax.set_ylim(self.y[0], self.y[-1])
 
     def show_section(self, *args, **kwargs):
         """Show a section.
@@ -482,7 +502,8 @@ class DataCube(BaseCube):
     number of attached attributes (grain size, mud frac, elevation).
     """
 
-    def __init__(self, data, read=[], varset=None, stratigraphy_from=None):
+    def __init__(self, data, read=[], varset=None, stratigraphy_from=None,
+                 coordinates={}):
         """Initialize the BaseCube.
 
         Parameters
@@ -511,7 +532,7 @@ class DataCube(BaseCube):
             with the :meth:`~deltametrics.cube.DataCube.stratigraphy_from`
             method.
         """
-        super().__init__(data, read, varset)
+        super().__init__(data, read, varset, coordinates)
 
         self._t = np.array(self._dataio['time'], copy=True)
         _, self._T, _ = np.meshgrid(self.y, self.t, self.x)
@@ -635,7 +656,8 @@ class StratigraphyCube(BaseCube):
 
     """
     @staticmethod
-    def from_DataCube(DataCubeInstance, stratigraphy_from='eta', dz=0.1):
+    def from_DataCube(DataCubeInstance, stratigraphy_from='eta',
+                      dz=None, z=None):
         """Create from a DataCube.
 
         Examples
@@ -668,10 +690,11 @@ class StratigraphyCube(BaseCube):
         """
         return StratigraphyCube(DataCubeInstance,
                                 stratigraphy_from=stratigraphy_from,
-                                dz=dz)
+                                dz=dz, z=z)
 
     def __init__(self, data, read=[], varset=None,
-                 stratigraphy_from=None, dz=None):
+                 stratigraphy_from=None, coordinates={},
+                 dz=None, z=None):
         """Initialize the StratigraphicCube.
 
         Any instantiation pathway must configure :obj:`z`, :obj:`H`, :obj:`L`,
@@ -695,7 +718,7 @@ class StratigraphyCube(BaseCube):
             to style this cube similarly to another cube. If no argument is
             supplied, a new default VariableSet instance is created.
         """
-        super().__init__(data, read, varset)
+        super().__init__(data, read, varset, coordinates)
         if isinstance(data, str):
             raise NotImplementedError('Precomputed NetCDF?')
         elif isinstance(data, np.ndarray):
@@ -705,7 +728,8 @@ class StratigraphyCube(BaseCube):
             _elev = copy.deepcopy(data[stratigraphy_from])
 
             # set up coordinates of the array
-            self._z = strat._determine_strat_coordinates(_elev.data, dz=dz)
+            self._z = strat._determine_strat_coordinates(
+                _elev.data, dz=dz, z=z)
             self._H = len(self.z)
             self._L, self._W = _elev.shape[1:]
             self._Z = np.tile(self.z, (self.W, self.L, 1)).T

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -189,6 +189,7 @@ class BaseCube(abc.ABC):
         """
         default_coordinates = {'x': 'x', 'y': 'y'}
         default_coordinates.update(coordinates)
+        self.coordinates = copy.deepcopy(default_coordinates)
         self._coords = self._dataio.known_coords
         self._variables = self._dataio.known_variables
         # if x is 2-D then we assume x and y are mesh grid values
@@ -436,9 +437,9 @@ class BaseCube(abc.ABC):
 
         _dx = self.x[1] - self.x[0]
         _extent = [self._x[0] - (_dx/2),
-                   self._x[-1] - (_dx/2),
-                   self._y[0] - (_dx/2),
-                   self._y[-1] - (_dx/2)]
+                   self._x[-1] + (_dx/2),
+                   self._y[-1] + (_dx/2),
+                   self._y[0] - (_dx/2)]
 
         if not ax:
             ax = plt.gca()
@@ -657,7 +658,7 @@ class StratigraphyCube(BaseCube):
     """
     @staticmethod
     def from_DataCube(DataCubeInstance, stratigraphy_from='eta',
-                      dz=None, z=None):
+                      dz=None, z=None, nz=None):
         """Create from a DataCube.
 
         Examples
@@ -690,11 +691,12 @@ class StratigraphyCube(BaseCube):
         """
         return StratigraphyCube(DataCubeInstance,
                                 stratigraphy_from=stratigraphy_from,
-                                dz=dz, z=z)
+                                coordinates=DataCubeInstance.coordinates,
+                                dz=dz, z=z, nz=nz)
 
     def __init__(self, data, read=[], varset=None,
                  stratigraphy_from=None, coordinates={},
-                 dz=None, z=None):
+                 dz=None, z=None, nz=None):
         """Initialize the StratigraphicCube.
 
         Any instantiation pathway must configure :obj:`z`, :obj:`H`, :obj:`L`,
@@ -729,7 +731,7 @@ class StratigraphyCube(BaseCube):
 
             # set up coordinates of the array
             self._z = strat._determine_strat_coordinates(
-                _elev.data, dz=dz, z=z)
+                _elev.data, dz=dz, z=z, nz=nz)
             self._H = len(self.z)
             self._L, self._W = _elev.shape[1:]
             self._Z = np.tile(self.z, (self.W, self.L, 1)).T

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -178,8 +178,9 @@ class NetCDFIO(BaseIO):
                 self.dataset = _dataset.set_coords([])
                 warn('Dimensions "time", "y", and "x" not provided in the \
                       given data file.', UserWarning)
-        except Exception:
-            raise TypeError('File format out of scope for DeltaMetrics')
+        except Exception as e:
+            raise TypeError(
+                f'File format out of scope for DeltaMetrics: {e}')
 
         try:
             _meta = xr.open_dataset(self.data_path, group='meta',

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1240,7 +1240,7 @@ def compute_channel_width(channelmask, section=None, return_widths=False):
     """
     if not (section is None):
         if issubclass(type(section), dm_section.BaseSection):
-            section_trace = section.trace
+            section_trace = section._xytrace
             section_coord = section._s
         elif isinstance(section, np.ndarray):
             section_trace = section
@@ -1276,7 +1276,14 @@ def compute_channel_width(channelmask, section=None, return_widths=False):
 
 
 def _get_channel_starts_and_ends(channelmask, section_trace):
-    """Get channel start and end coordinates (internal function)."""
+    """Get channel start and end coordinates (internal function).
+
+    .. important::
+
+        section_trace must be the index coordinates of the section trace, and
+        not the coordinate values that are returned from `section.trace`.
+
+    """
     _channelseries = channelmask[section_trace[:, 1],
                                  section_trace[:, 0]].astype(int)
     _padchannelseries = np.pad(_channelseries, (1,), 'constant',
@@ -1343,7 +1350,7 @@ def compute_channel_depth(channelmask, depth, section=None,
     """
     if not (section is None):
         if issubclass(type(section), dm_section.BaseSection):
-            section_trace = section.trace
+            section_trace = section._xytrace
             section_coord = section._s
         elif isinstance(section, np.ndarray):
             section_trace = section

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -70,7 +70,7 @@ def golf():
         plt.show()
     """
     golf_path = _get_golf_path()
-    return cube.DataCube(golf_path)
+    return cube.DataCube(golf_path, coordinates={'x': 'y', 'y': 'x'})
 
 
 def tdb12():

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -280,7 +280,9 @@ class BaseSection(abc.ABC):
              + (self._y[1:] - self._y[:-1])**2))))
         self._z = self.cube.z
         self._shape = (len(self._z), len(self._s))
-        self._trace = np.column_stack((self._x, self._y))
+        self._xytrace = np.column_stack((self._x, self._y))
+        self._trace = np.column_stack((self.cube.x[self._x],
+                                       self.cube.y[self._y]))
 
     @property
     def trace(self):
@@ -432,34 +434,34 @@ class BaseSection(abc.ABC):
 
         .. doctest::
 
-            >>> rcm8cube = dm.sample_data.rcm8()
-            >>> rcm8cube.register_section(
+            >>> golfcube = dm.sample_data.golf()
+            >>> golfcube.register_section(
             ...     'demo', dm.section.StrikeSection(y=5))
-            >>> rcm8cube.sections['demo'].show('velocity')
+            >>> golfcube.sections['demo'].show('velocity')
 
         .. plot:: section/section_demo_spacetime.py
 
         Note that the last line above is functionally equivalent to
-        ``rcm8cube.show_section('demo', 'velocity')``.
+        ``golfcube.show_section('demo', 'velocity')``.
 
         *Example 2:* Display a section, with "quick" stratigraphy, as the
         `depth` attribute, displaying several different section styles.
 
         .. doctest::
 
-            >>> rcm8cube = dm.sample_data.rcm8()
-            >>> rcm8cube.stratigraphy_from('eta')
-            >>> rcm8cube.register_section(
+            >>> golfcube = dm.sample_data.golf()
+            >>> golfcube.stratigraphy_from('eta')
+            >>> golfcube.register_section(
             ...     'demo', dm.section.StrikeSection(y=5))
 
             >>> fig, ax = plt.subplots(4, 1, sharex=True, figsize=(6, 9))
-            >>> rcm8cube.sections['demo'].show('depth', data='spacetime',
+            >>> golfcube.sections['demo'].show('depth', data='spacetime',
             ...                                 ax=ax[0], label='spacetime')
-            >>> rcm8cube.sections['demo'].show('depth', data='preserved',
+            >>> golfcube.sections['demo'].show('depth', data='preserved',
             ...                                ax=ax[1], label='preserved')
-            >>> rcm8cube.sections['demo'].show('depth', data='stratigraphy',
+            >>> golfcube.sections['demo'].show('depth', data='stratigraphy',
             ...                                ax=ax[2], label='quick stratigraphy')
-            >>> rcm8cube.sections['demo'].show('depth', style='lines', data='stratigraphy',
+            >>> golfcube.sections['demo'].show('depth', style='lines', data='stratigraphy',
             ...                                ax=ax[3], label='quick stratigraphy')          # noqa: E501
 
         .. plot:: section/section_demo_quick_strat.py
@@ -509,7 +511,7 @@ class BaseSection(abc.ABC):
         ax.set_xlim(xmin, xmax)
         ax.set_ylim(ymin, ymax)
 
-    def show_trace(self, *args, ax=None, **kwargs):
+    def show_trace(self, *args, ax=None, autoscale=False, **kwargs):
         """Plot section trace (x-y plane path).
 
         Plot the section trace (:obj:`trace`) onto an x-y planview.
@@ -524,6 +526,11 @@ class BaseSection(abc.ABC):
             provided, a call is made to ``plt.gca()`` to get the current (or
             create a new) `Axes` object.
 
+        autoscale : :obj:`bool`
+            Whether to rescale the axis based on the limits of the section.
+            Manipulates the `matplotlib` `autoscale` attribute. Default is
+            ``False``.
+
         **kwargs
             Passed to `matplotlib` :obj:`~matplotlib.pyplot.plot()`.
         """
@@ -532,7 +539,19 @@ class BaseSection(abc.ABC):
 
         _label = kwargs.pop('label', self.name)
 
-        ax.plot(self._x, self._y, label=_label, *args, **kwargs)
+        _x = self.cube.x[self._x]
+        _y = self.cube.y[self._y]
+
+        # get the limits to be able to reset if autoscale false
+        lims = [ax.get_xlim(), ax.get_ylim()]
+
+        # add the trace
+        ax.plot(_x, _y, label=_label, *args, **kwargs)
+
+        # if autscale is false, reset the axes
+        if not autoscale:
+            ax.set_xlim(*lims[0])
+            ax.set_ylim(*lims[1])
 
 
 class PathSection(BaseSection):
@@ -580,15 +599,15 @@ class PathSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> rcm8cube.register_section('path', dm.section.PathSection(
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section('path', dm.section.PathSection(
         ...     path=np.array([[50, 3], [65, 17], [130, 10]])))
         >>>
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
-        >>> rcm8cube.sections['path'].show_trace('r--', ax=ax[0])
-        >>> rcm8cube.sections['path'].show('velocity', ax=ax[1])
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.sections['path'].show_trace('r--', ax=ax[0])
+        >>> golfcube.sections['path'].show('velocity', ax=ax[1])
         >>> plt.show()
     """
 
@@ -682,14 +701,14 @@ class StrikeSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> rcm8cube.register_section('strike', dm.section.StrikeSection(y=10))
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section('strike', dm.section.StrikeSection(y=10))
         >>>
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
-        >>> rcm8cube.sections['strike'].show_trace('r--', ax=ax[0])
-        >>> rcm8cube.sections['strike'].show('velocity', ax=ax[1])
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.sections['strike'].show_trace('r--', ax=ax[0])
+        >>> golfcube.sections['strike'].show('velocity', ax=ax[1])
         >>> plt.show()
 
     Similarly, create a `StrikeSection` that is registered to a
@@ -699,14 +718,14 @@ class StrikeSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube)
+        >>> golfcube = dm.sample_data.golf()
+        >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(golfcube)
         >>> sc8cube.register_section(
         ...     'strike_half', dm.section.StrikeSection(y=20, x=[0, 120]))
 
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
         >>> sc8cube.sections['strike_half'].show_trace('r--', ax=ax[0])
         >>> sc8cube.sections['strike_half'].show('velocity', ax=ax[1])
         >>> plt.show()
@@ -780,14 +799,14 @@ class DipSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> rcm8cube.register_section('dip', dm.section.DipSection(x=130))
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section('dip', dm.section.DipSection(x=130))
         >>>
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
-        >>> rcm8cube.sections['dip'].show_trace('r--', ax=ax[0])
-        >>> rcm8cube.sections['dip'].show('velocity', ax=ax[1])
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.sections['dip'].show_trace('r--', ax=ax[0])
+        >>> golfcube.sections['dip'].show('velocity', ax=ax[1])
         >>> plt.show()
 
     Similarly, create a `DipSection` that is registered to a
@@ -797,14 +816,14 @@ class DipSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube)
+        >>> golfcube = dm.sample_data.golf()
+        >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(golfcube)
         >>> sc8cube.register_section(
         ...     'dip_short', dm.section.DipSection(y=[0, 50]))
 
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
         >>> sc8cube.sections['dip_short'].show_trace('r--', ax=ax[0])
         >>> sc8cube.sections['dip_short'].show('velocity', ax=ax[1])
         >>> plt.show()
@@ -895,15 +914,15 @@ class CircularSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> rcm8cube.register_section(
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section(
         ...     'circular', dm.section.CircularSection(radius=30))
 
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
-        >>> rcm8cube.sections['circular'].show_trace('r--', ax=ax[0])
-        >>> rcm8cube.sections['circular'].show('velocity', ax=ax[1])
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.sections['circular'].show_trace('r--', ax=ax[0])
+        >>> golfcube.sections['circular'].show('velocity', ax=ax[1])
         >>> plt.show()
     """
 
@@ -1012,15 +1031,15 @@ class RadialSection(BaseSection):
     .. plot::
         :include-source:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> rcm8cube.register_section(
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section(
         ...     'radial', dm.section.RadialSection(azimuth=45))
 
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
-        >>> rcm8cube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
-        >>> rcm8cube.sections['radial'].show_trace('r--', ax=ax[0])
-        >>> rcm8cube.sections['radial'].show('velocity', ax=ax[1])
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.sections['radial'].show_trace('r--', ax=ax[0])
+        >>> golfcube.sections['radial'].show('velocity', ax=ax[1])
         >>> plt.show()
     """
     def __init__(self, *args, azimuth=None, origin=None, length=None,

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -388,8 +388,9 @@ class BaseSection(abc.ABC):
         Parameters
         ----------
 
-        SectionAttribute : :obj:`str`
-            Which attribute to show.
+        SectionAttribute : :obj:`str`, :obj:`SectionVariableInstance`
+            Which attribute to show. Can be a string for a named `Cube`
+            attribute, or any arbitrary data.
 
         style : :obj:`str`, optional
             What style to display the section with. Choices are 'mesh' or

--- a/deltametrics/strat.py
+++ b/deltametrics/strat.py
@@ -1,4 +1,5 @@
 import abc
+import warnings
 
 import numpy as np
 import xarray as xr
@@ -525,8 +526,12 @@ def _determine_strat_coordinates(elev, z=None, dz=None, nz=None):
 
     .. note::
 
-        At least one of the optional parameters must be supplied. Precedence
-        when multiple arguments are supplied is `z`, `dz`, `nz`.
+        If none of the optional parameters is supplied, then a default value
+        is used of `dz=0.1`.
+
+    .. important::
+        
+        Precedence when multiple arguments are supplied is `z`, `dz`, `nz`.
 
     Parameters
     ----------
@@ -545,10 +550,18 @@ def _determine_strat_coordinates(elev, z=None, dz=None, nz=None):
         Number of intervals in `z`. Z array is created as
         ``np.linspace(np.min(elev), np.max(elev), num=nz, endpoint=True)``.
     """
+    # if nothing is supplied
     if (dz is None) and (z is None) and (nz is None):
-        raise ValueError('You must specify "z", "dz", or "nz.')
+        warnings.warn(
+            UserWarning('No specification for stratigraphy spacing '
+                        'was supplied. Default is to use `dz=0.1`'))
+        # set the default option when nothing is supplied
+        dz = 0.1
 
+    # set up an error message to use in a few places
     _valerr = ValueError('"dz" or "nz" cannot be zero or negative.')
+    
+    # process to find the option to set up z
     if not (z is None):
         if np.isscalar(z):
             raise ValueError('"z" must be a numpy array.')

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -32,20 +32,20 @@ For now, let's use a sample dataset that is distributed with DeltaMetrics.
 
 .. doctest::
 
-    >>> rcm8cube = dm.sample_data.rcm8()
-    >>> type(rcm8cube)
+    >>> golfcube = dm.sample_data.golf()
+    >>> type(golfcube)
     <class 'deltametrics.cube.DataCube'>
 
 This creates an instance of a :obj:`~deltametrics.cube.DataCube` object, which is the simplest and most commonly used type of cube.
 "Cubes" in DeltaMetrics language are the central office that connects all the different modules and workflows together.
-Creating the ``rcm8cube`` connects to a dataset, but does not read any of the data into memory, allowing for efficient computation on large datasets.
+Creating the ``golfcube`` connects to a dataset, but does not read any of the data into memory, allowing for efficient computation on large datasets.
 
-Inspect which variables are available in the ``rcm8cube``.
+Inspect which variables are available in the ``golfcube``.
 
 .. doctest::
 
-    >>> rcm8cube.variables
-    ['eta', 'stage', 'depth', 'discharge', 'velocity', 'strata_sand_frac']
+    >>> golfcube.variables
+    ['eta', 'stage', 'depth', 'discharge', 'velocity', 'sandfrac']
 
 
 Accessing data from a DataCube
@@ -56,17 +56,17 @@ Slicing a cube returns an instance of :obj:`~deltametrics.cube.CubeVariable`, wh
 
 .. doctest::
 
-    >>> type(rcm8cube['velocity'])
+    >>> type(golfcube['velocity'])
     <class 'deltametrics.cube.CubeVariable'>
 
-    >>> type(rcm8cube['velocity'].data)
+    >>> type(golfcube['velocity'].data)
     <class 'xarray.core.dataarray.DataArray'>
 
 The underlying xarray object can be directly accessed by using a ``.data`` attribute, however, this is not necessary, and you can slice the `CubeVariable` directly with any valid `numpy` slicing style. For example, we could determine how much the average bed elevation changed at a specific location in the model domain (43, 123), by slicing the ``eta`` variable, and differencing timesteps.
 
 .. doctest::
 
-    >>> np.mean( rcm8cube['eta'][1:,43,123] - rcm8cube['eta'][:-1,43,123] )
+    >>> np.mean( golfcube['eta'][1:,43,123] - golfcube['eta'][:-1,43,123] )
     <xarray.DataArray 'eta' ()>
     array(0.08364895, dtype=float32)
     Coordinates:
@@ -97,9 +97,9 @@ of the Cube at the fortieth (40th) timestep:
     >>> import matplotlib.pyplot as plt
 
     >>> fig, ax = plt.subplots(1, 3)
-    >>> rcm8cube.show_plan('eta', t=40, ax=ax[0])
-    >>> rcm8cube.show_plan('velocity', t=40, ax=ax[1], ticks=True)
-    >>> rcm8cube.show_plan('strata_sand_frac', t=40, ax=ax[2])
+    >>> golfcube.show_plan('eta', t=40, ax=ax[0])
+    >>> golfcube.show_plan('velocity', t=40, ax=ax[1], ticks=True)
+    >>> golfcube.show_plan('strata_sand_frac', t=40, ax=ax[2])
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/10min_three_plans.py
@@ -116,7 +116,7 @@ We must directly tell the Cube instance to compute stratigraphy by specifying wh
 
 .. doctest::
 
-    >>> rcm8cube.stratigraphy_from('eta')
+    >>> golfcube.stratigraphy_from('eta')
 
 For this example, the stratigraphic computation is relatively fast (< one second), but for large data domains covering a large amount of time, this computation may not be as fast.
 The stratigraphy computed via `stratigraphy_from` is often referred to as "quick" stratigraphy, and may be helpful for visualizing cross sections of the deposit, but we recommend creating a :obj:`~deltametrics.cube.StratigraphyCube` from a `DataCube` for thorough analysis of stratigraphy.
@@ -127,23 +127,23 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
 .. doctest::
 
-    >>> rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 which can then be accessed via the :obj:`~deltametrics.cube.Cube.sections` attribute of the Cube.
 
 .. doctest::
 
-    >>> rcm8cube.sections['demo']
+    >>> golfcube.sections['demo']
     <deltametrics.section.StrikeSection object at 0x...>
 
-Using the "quick" stratigraphy, we can visualize all of the available data variables (and `'time'`) as stratigraphy:
+Using the "quick" stratigraphy, we can visualize a few of the available data variables as stratigraphy:
 
 .. doctest::
 
-    >>> fig, ax = plt.subplots(7, 1, sharex=True, figsize=(8,5))
+    >>> fig, ax = plt.subplots(5, 1, sharex=True, figsize=(8,5))
     >>> ax = ax.flatten()
-    >>> for i, var in enumerate(['time'] + rcm8cube.dataio.known_variables):
-    ...    rcm8cube.show_section('demo', var, data='stratigraphy', ax=ax[i])
+    >>> for i, var in enumerate(['time', 'eta', 'velocity', 'discharge', 'sandfrac']):
+    ...    golfcube.show_section('demo', var, data='stratigraphy', ax=ax[i], label=True)
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/10min_all_sections_strat.py

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -45,7 +45,7 @@ Inspect which variables are available in the ``golfcube``.
 .. doctest::
 
     >>> golfcube.variables
-    ['eta', 'stage', 'depth', 'discharge', 'velocity', 'sandfrac']
+    ['eta', 'stage', 'depth', 'discharge', 'velocity', 'sedflux', 'sandfrac']
 
 
 Accessing data from a DataCube
@@ -68,10 +68,11 @@ The underlying xarray object can be directly accessed by using a ``.data`` attri
 
     >>> np.mean( golfcube['eta'][1:,43,123] - golfcube['eta'][:-1,43,123] )
     <xarray.DataArray 'eta' ()>
-    array(0.08364895, dtype=float32)
+    array(0., dtype=float32)
     Coordinates:
-        x        float32 123.0
-        y        float32 43.0
+        x        float32 2.15e+03
+        y        float32 6.15e+03
+
 
 
 The DataCube is often used by taking horizontal or vertical "cuts" of the cube.
@@ -99,7 +100,7 @@ of the Cube at the fortieth (40th) timestep:
     >>> fig, ax = plt.subplots(1, 3)
     >>> golfcube.show_plan('eta', t=40, ax=ax[0])
     >>> golfcube.show_plan('velocity', t=40, ax=ax[1], ticks=True)
-    >>> golfcube.show_plan('strata_sand_frac', t=40, ax=ax[2])
+    >>> golfcube.show_plan('sandfrac', t=40, ax=ax[2])
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/10min_three_plans.py
@@ -116,7 +117,7 @@ We must directly tell the Cube instance to compute stratigraphy by specifying wh
 
 .. doctest::
 
-    >>> golfcube.stratigraphy_from('eta')
+    >>> golfcube.stratigraphy_from('eta', dz=0.1)
 
 For this example, the stratigraphic computation is relatively fast (< one second), but for large data domains covering a large amount of time, this computation may not be as fast.
 The stratigraphy computed via `stratigraphy_from` is often referred to as "quick" stratigraphy, and may be helpful for visualizing cross sections of the deposit, but we recommend creating a :obj:`~deltametrics.cube.StratigraphyCube` from a `DataCube` for thorough analysis of stratigraphy.

--- a/docs/source/guides/examples/index.rst
+++ b/docs/source/guides/examples/index.rst
@@ -9,6 +9,7 @@ Examples of how to do various tasks and visualizations in DeltaMetrics.
    :maxdepth: 1
 
    io/connect_to_nonstandard_data
+   io/setup_any_dataset
    plot/show_plan
    plot/show_section
    computations/preserved_velocities

--- a/docs/source/guides/examples/io/setup_any_dataset.rst
+++ b/docs/source/guides/examples/io/setup_any_dataset.rst
@@ -1,0 +1,11 @@
+How to set up any dataset to work with DeltaMetrics
+---------------------------------------------------
+
+This guide describes how to set up any `t-x-y` dataset to work with DeltaMetrics. 
+
+
+Connecting with NetCDF
+~~~~~~~~~~~~~~~~~~~~~~
+
+The standard I/O format for data used in DeltaMetrics is a NetCDF4 file, structured as sets of arrays. 
+NetCDF was designed with dimensional data in mind, so that we can use common dimensions to 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -48,17 +48,17 @@ DeltaMetrics centers around the use of “Cubes” in DeltaMetrics language are 
 
 .. doctest::
 
-    >>> rcm8cube = dm.sample_data.rcm8()
-    >>> rcm8cube
+    >>> golfcube = dm.sample_data.golf()
+    >>> golfcube
     <deltametrics.cube.DataCube object at 0x...>
 
-Creating the ``rcm8cube`` connects to a dataset, but does not read any of the data into memory, allowing for efficient computation on large datasets. The type of the ``rcm8cube`` is ``DataCube``.
+Creating the ``golfcube`` connects to a dataset, but does not read any of the data into memory, allowing for efficient computation on large datasets. The type of the ``golfcube`` is ``DataCube``.
 
-Inspect which variables are available in the ``rcm8cube``.
+Inspect which variables are available in the ``golfcube``.
 
 .. doctest::
 
-    >>> rcm8cube.variables
+    >>> golfcube.variables
     ['eta', 'stage', 'depth', 'discharge', 'velocity', 'strata_sand_frac']
 
 We can access the underlying variables by name. The returned object are xarray-accessors with coordinates ``t-x-y``.
@@ -66,9 +66,9 @@ For example, access variables as:
 
 .. doctest::
 
-    >>> type(rcm8cube['eta'])
+    >>> type(golfcube['eta'])
     <class 'deltametrics.cube.CubeVariable'>
-    >>> rcm8cube['eta'].shape
+    >>> golfcube['eta'].shape
     (51, 120, 240)
 
 Let’s examine the timeseries of bed elevations by taking slices out of the ``'eta'`` variable, at various indicies (``t``) along the 0th dimension.
@@ -76,11 +76,11 @@ Let’s examine the timeseries of bed elevations by taking slices out of the ``'
 .. doctest::
 
     >>> nt = 5
-    >>> ts = np.linspace(0, rcm8cube['eta'].shape[0]-1, num=nt, dtype=np.int)  # linearly interpolate ts
+    >>> ts = np.linspace(0, golfcube['eta'].shape[0]-1, num=nt, dtype=int)  # linearly interpolate ts
 
     >>> fig, ax = plt.subplots(1, nt, figsize=(12, 2))
     >>> for i, t in enumerate(ts):
-    ...     ax[i].imshow(rcm8cube['eta'][t, :, :], vmin=-5, vmax=0.5) #doctest: +SKIP
+    ...     ax[i].imshow(golfcube['eta'][t, :, :], vmin=-2, vmax=0.5) #doctest: +SKIP
     ...     ax[i].set_title('t = ' + str(t)) #doctest: +SKIP
     ...     ax[i].axes.get_xaxis().set_ticks([]) #doctest: +SKIP
     ...     ax[i].axes.get_yaxis().set_ticks([]) #doctest: +SKIP
@@ -100,7 +100,7 @@ For example:
 .. doctest::
 
     >>> # compute the change in bed elevation between the last two intervals above
-    >>> diff_time = rcm8cube['eta'][ts[-1], ...] - rcm8cube['eta'][ts[-2], ...]
+    >>> diff_time = golfcube['eta'][ts[-1], ...] - golfcube['eta'][ts[-2], ...]
 
     >>> fig, ax = plt.subplots(figsize=(5, 3))
     >>> im = ax.imshow(diff_time, cmap='RdBu', vmax=abs(diff_time).max(), vmin=-abs(diff_time).max())
@@ -148,7 +148,7 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
 .. doctest::
 
-    >>> rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 which creates a section across a constant y-value ``==10``.
 The path of any `Section` in the ``x-y`` plane can always be accessed via the ``.trace`` attribute.
@@ -157,9 +157,9 @@ We can plot the trace on top the the final bed elevation to see where the sectio
 .. doctest::
 
     >>> fig, ax = plt.subplots()
-    >>> rcm8cube.show_plan('eta', t=-1, ax=ax, ticks=True)
-    >>> ax.plot(rcm8cube.sections['demo'].trace[:,0],
-    ...         rcm8cube.sections['demo'].trace[:,1], 'r--') #doctest: +SKIP
+    >>> golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)
+    >>> ax.plot(golfcube.sections['demo'].trace[:,0],
+    ...         golfcube.sections['demo'].trace[:,1], 'r--') #doctest: +SKIP
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/userguide_strikesection_location.py
@@ -168,7 +168,7 @@ Any registered section can then be accessed via the :obj:`~deltametrics.cube.Cub
 
 .. doctest::
 
-    >>> rcm8cube.sections['demo']
+    >>> golfcube.sections['demo']
     <deltametrics.section.StrikeSection object at 0x...>
 
 Available section types are ``PathSection``, ``StrikeSection``,
@@ -178,8 +178,8 @@ are sliced themselves, similarly to the cube.
 
 .. doctest::
 
-    >>> rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
-    >>> rcm8cube.sections['demo']['velocity']
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube.sections['demo']['velocity']
     DataSectionVariable([[0., 0., 0., ..., 0., 0., 0.],
                          [0., 0., 0., ..., 0., 0., 0.],
                          [0., 0., 0., ..., 0., 0., 0.],
@@ -193,9 +193,9 @@ We can visualize sections:
 .. doctest::
 
     >>> fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12,6))
-    >>> rcm8cube.show_section('demo', 'eta', ax=ax[0])
-    >>> rcm8cube.show_section('demo', 'velocity', ax=ax[1])
-    >>> rcm8cube.show_section('demo', 'strata_sand_frac', ax=ax[2])
+    >>> golfcube.show_section('demo', 'eta', ax=ax[0])
+    >>> golfcube.show_section('demo', 'velocity', ax=ax[1])
+    >>> golfcube.show_section('demo', 'strata_sand_frac', ax=ax[2])
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/userguide_three_spacetime_sections.py
@@ -205,8 +205,8 @@ You can also create a standalone section, which is not registered to the cube, b
 
 .. doctest::
 
-    >>> sass = dm.section.StrikeSection(rcm8cube, y=10)
-    >>> np.all(sass['velocity'] == rcm8cube.sections['demo']['velocity']) #doctest: +SKIP
+    >>> sass = dm.section.StrikeSection(golfcube, y=10)
+    >>> np.all(sass['velocity'] == golfcube.sections['demo']['velocity']) #doctest: +SKIP
     True
 
 .. _userguide_quick_stratigraphy:
@@ -223,13 +223,13 @@ Compute the quick stratigraphy as:
 
 .. doctest::
 
-    >>> rcm8cube.stratigraphy_from('eta')
+    >>> golfcube.stratigraphy_from('eta')
 
 Now, the ``DataCube`` has knowledge of stratigraphy, which we can further use to visualize preservation within the spacetime, or visualize as an actual stratigraphic slice.
 
 .. doctest::
 
-    >>> rcm8cube.sections['demo']['velocity'].as_preserved()
+    >>> golfcube.sections['demo']['velocity'].as_preserved()
     masked_DataSectionVariable(
       data=[[0.0, 0.0, 0.0, ..., 0.0, 0.0, 0.0],
             [--, --, --, ..., --, --, --],
@@ -251,9 +251,9 @@ Now, the ``DataCube`` has knowledge of stratigraphy, which we can further use to
 .. doctest::
 
     >>> fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 8))
-    >>> rcm8cube.show_section('demo', 'velocity', ax=ax[0])
-    >>> rcm8cube.show_section('demo', 'velocity', data='preserved', ax=ax[1])
-    >>> rcm8cube.show_section('demo', 'velocity', data='stratigraphy', ax=ax[2])
+    >>> golfcube.show_section('demo', 'velocity', ax=ax[0])
+    >>> golfcube.show_section('demo', 'velocity', data='preserved', ax=ax[1])
+    >>> golfcube.show_section('demo', 'velocity', data='stratigraphy', ax=ax[2])
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/userguide_quick_stratigraphy_sections.py
@@ -263,10 +263,10 @@ Quick stratigraphy makes it easy to visualize the behavior of the model across e
 
 .. doctest::
 
-    >>> fig, ax = plt.subplots(7, 1, sharex=True, sharey=True, figsize=(12, 12))
+    >>> fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 12))
     >>> ax = ax.flatten()
-    >>> for i, var in enumerate(['time'] + rcm8cube.dataio.known_variables):
-    ...     rcm8cube.show_section('demo', var, ax=ax[i], label=True,
+    >>> for i, var in enumerate(['time', 'eta', 'velocity', 'discharge', 'sandfrac']):
+    ...     golfcube.show_section('demo', var, ax=ax[i], label=True,
     ...       style='shaded', data='stratigraphy')
     >>> plt.show() #doctest: +SKIP
 
@@ -282,11 +282,11 @@ The following are currently implemented.
 
 .. doctest::
 
-    >>> _strike = dm.section.StrikeSection(rcm8cube, y=18)
-    >>> _path = dm.section.PathSection(rcm8cube, path=np.column_stack((np.linspace(50, 150, num=4000, dtype=np.int),
-    ...                                                                np.linspace(10, 90, num=4000, dtype=np.int))))
-    >>> _circ = dm.section.CircularSection(rcm8cube, radius=30)
-    >>> _rad = dm.section.RadialSection(rcm8cube, azimuth=70)
+    >>> _strike = dm.section.StrikeSection(golfcube, y=18)
+    >>> _path = dm.section.PathSection(golfcube, path=np.column_stack((np.linspace(50, 150, num=4000, dtype=int),
+    ...                                                                np.linspace(10, 90, num=4000, dtype=int))))
+    >>> _circ = dm.section.CircularSection(golfcube, radius=40)
+    >>> _rad = dm.section.RadialSection(golfcube, azimuth=70)
 
 
 The `Section` classes all inherit from the same ``BaseSection`` class, which means they mostly have the same options available to them, and have a common API.
@@ -299,7 +299,7 @@ Each has unique instantiation arguments, though, which must be properly specifie
     >>> ax0 = fig.add_subplot(spec[0, :])
     >>> axs = [fig.add_subplot(spec[i, j]) for i, j in zip(np.repeat(np.arange(1, 3), 2), np.tile(np.arange(2), (3,)))]
 
-    >>> rcm8cube.show_plan('eta', t=-1, ax=ax0, ticks=True)
+    >>> golfcube.show_plan('eta', t=-1, ax=ax0, ticks=True)
     >>> for i, s in enumerate([_strike, _path, _circ, _rad]):
     ...     ax0.plot(s.trace[:,0], s.trace[:,1], 'r--') #doctest: +SKIP
     ...     s.show('velocity', ax=axs[i]) #doctest: +SKIP
@@ -325,7 +325,7 @@ Here’s a simple example to demonstrate how we place data into the stratigraphy
 
 .. doctest::
 
-    >>> ets = rcm8cube['eta'][:, 25, 120]  # a "real" slice of the model
+    >>> ets = golfcube['eta'][:, 10, 85]  # a "real" slice of the model
     >>> fig, ax = plt.subplots(figsize=(8, 4))
     >>> dm.plot.show_one_dimensional_trajectory_to_strata(ets, ax=ax, dz=0.25)
     >>> plt.show() #doctest: +SKIP
@@ -337,19 +337,19 @@ Begin by creating a ``StratigraphyCube``:
 
 .. doctest::
 
-    >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-    >>> sc8cube.variables
-    ['eta', 'stage', 'depth', 'discharge', 'velocity', 'strata_sand_frac']
+    >>> stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+    >>> stratcube.variables
+    ['eta', 'stage', 'depth', 'discharge', 'velocity', 'sandfrac']
 
 
 We can then slice this cube in the same way as the ``DataCube``, but what we get back is *stratigraphy* rather than *spacetime*.
-Compare the slice from the `rcm8cube` (left) to the `sc8cube` (right):
+Compare the slice from the `golfcube` (left) to the `stratcube` (right):
 
 .. doctest::
 
     >>> fig, ax = plt.subplots(1, 2, figsize=(8, 2))
-    >>> rcm8cube.sections['demo'].show('velocity', ax=ax[0]) #doctest: +SKIP
-    >>> sc8cube.sections['demo'].show('velocity', ax=ax[1]) #doctest: +SKIP
+    >>> golfcube.sections['demo'].show('velocity', ax=ax[0]) #doctest: +SKIP
+    >>> stratcube.sections['demo'].show('velocity', ax=ax[1]) #doctest: +SKIP
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/userguide_compare_slices.py
@@ -358,12 +358,12 @@ Compare the slice from the `rcm8cube` (left) to the `sc8cube` (right):
 Validation of the stratigraphy is easily seen by looking at the ``time`` attribute.
 Note that sections are *not* inherited from the ``DataCube`` by default (we’re working on this and related features).
 
-Let’s add a section at the same location as ``rcm8cube.sections['demo']``.
+Let’s add a section at the same location as ``golfcube.sections['demo']``.
 
 .. doctest::
 
-    >>> sc8cube.register_section('demo', dm.section.StrikeSection(y=10))
-    >>> sc8cube.sections
+    >>> stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> stratcube.sections
     {'demo': <deltametrics.section.StrikeSection object at 0x...>}
 
 Let's examine the stratigraphy in three different visual styles.
@@ -371,9 +371,9 @@ Let's examine the stratigraphy in three different visual styles.
 .. doctest::
 
     >>> fig, ax = plt.subplots(3, 1, sharex=True, sharey=True, figsize=(12, 8))
-    >>> rcm8cube.sections['demo'].show('time', style='lines', data='stratigraphy', ax=ax[0], label=True)
-    >>> sc8cube.sections['demo'].show('time', ax=ax[1])
-    >>> rcm8cube.sections['demo'].show('time', data='stratigraphy', ax=ax[2])
+    >>> golfcube.sections['demo'].show('time', style='lines', data='stratigraphy', ax=ax[0], label=True)
+    >>> stratcube.sections['demo'].show('time', ax=ax[1])
+    >>> golfcube.sections['demo'].show('time', data='stratigraphy', ax=ax[2])
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/userguide_three_stratigraphy.py
@@ -384,8 +384,8 @@ Similar to the demonstration above, each variable (property) of the underlying c
 
     >>> fig, ax = plt.subplots(7, 1, sharex=True, sharey=True, figsize=(12, 12))
     >>> ax = ax.flatten()
-    >>> for i, var in enumerate(['time'] + sc8cube.dataio.known_variables):
-    ...     sc8cube.show_section('demo', var, ax=ax[i], label=True,
+    >>> for i, var in enumerate(['time'] + stratcube.dataio.known_variables):
+    ...     stratcube.show_section('demo', var, ax=ax[i], label=True,
     ...                          style='shaded', data='stratigraphy')
     >>> plt.show() #doctest: +SKIP
 
@@ -398,10 +398,10 @@ values. This might be done by subclassing ``xarray`` rather than
 
 .. doctest::
 
-    >>> elev_idx = (np.abs(sc8cube.z - -2)).argmin()  # find nearest idx to -2 m
+    >>> elev_idx = (np.abs(stratcube.z - -2)).argmin()  # find nearest idx to -2 m
 
     >>> fig, ax = plt.subplots(figsize=(5, 3))
-    >>> sc8cube.show_plan('strata_sand_frac', elev_idx, ticks=True)
+    >>> stratcube.show_plan('strata_sand_frac', elev_idx, ticks=True)
     >>> plt.show() #doctest: +SKIP
 
 .. plot:: guides/userguide_stratigraphy_planform_slice.py
@@ -415,15 +415,15 @@ speed up computations if an array is being accessed over and over.
 
 .. code::
 
-    fs = sc8cube.export_frozen_variable('strata_sand_frac')
-    fe = sc8cube.Z  # exported volume does not have coordinate information!
+    fs = stratcube.export_frozen_variable('strata_sand_frac')
+    fe = stratcube.Z  # exported volume does not have coordinate information!
 
     fig, ax = plt.subplots(figsize=(10, 2))
     pcm = ax.pcolormesh(np.tile(np.arange(fs.shape[2]), (fs.shape[0], 1)),
        fe[:,10,:], fs[:,10,:], shading='auto',
-       cmap=rcm8cube.varset['strata_sand_frac'].cmap,
-       vmin=rcm8cube.varset['strata_sand_frac'].vmin,
-       vmax=rcm8cube.varset['strata_sand_frac'].vmax)
+       cmap=golfcube.varset['strata_sand_frac'].cmap,
+       vmin=golfcube.varset['strata_sand_frac'].vmin,
+       vmax=golfcube.varset['strata_sand_frac'].vmax)
     dm.plot.append_colorbar(pcm, ax)
     plt.show() #doctest: +SKIP
 
@@ -432,7 +432,7 @@ and just directly obtain a frozen volume with:
 
 .. doctest::
 
-   >>> fs, fe = dm.strat.compute_boxy_stratigraphy_volume(rcm8cube['eta'], rcm8cube['strata_sand_frac'], dz=0.05)
+   >>> fs, fe = dm.strat.compute_boxy_stratigraphy_volume(golfcube['eta'], golfcube['strata_sand_frac'], dz=0.05)
 
 However, this will require recomputing the stratigraphy preservation to create another cube in the future, and because the ``StratigraphyCube`` stores data on disk, the memory footprint is relatively small, and so we recommend just computing the ``StratigraphyCube`` and using the ``export_frozen_variable)`` method.
 Finally, ``DataCubeVariable`` and ``StratigraphyCubeVariable`` support a ``.as_frozen()`` method themselves.
@@ -441,7 +441,7 @@ We should verify that the frozen cubes actually match the underlying data!
 
 .. doctest::
 
-    >>> np.all( fs[~np.isnan(fs)] == sc8cube['strata_sand_frac'][~np.isnan(sc8cube['strata_sand_frac'])] ) #doctest: +SKIP
+    >>> np.all( fs[~np.isnan(fs)] == stratcube['strata_sand_frac'][~np.isnan(stratcube['strata_sand_frac'])] ) #doctest: +SKIP
     True
 
 The access speed of a frozen volume is **much** faster than a live cube.

--- a/docs/source/pyplots/examples/preserved_velocities.py
+++ b/docs/source/pyplots/examples/preserved_velocities.py
@@ -2,8 +2,8 @@ import numpy as np
 import deltametrics as dm
 import matplotlib.pyplot as plt
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
 
 
 def pick_velocities(sect):
@@ -22,14 +22,14 @@ def pick_velocities(sect):
 
 
 # preallocate
-_ys = np.arange(10, 110, step=2)  # sections to examine
-_mall = np.full_like(_ys, np.nan, dtype=np.float)
-_mstrat = np.full_like(_ys, np.nan, dtype=np.float)
+_ys = np.arange(10, 90, step=2)  # sections to examine
+_mall = np.full_like(_ys, np.nan, dtype=float)
+_mstrat = np.full_like(_ys, np.nan, dtype=float)
 
 
 # loop through all of the sections defined in _ys
 for i, _y in enumerate(_ys):
-    _s = dm.section.StrikeSection(rcm8cube, y=_y)
+    _s = dm.section.StrikeSection(golfcube, y=_y)
     _mall[i], _mstrat[i] = pick_velocities(_s)
 
 

--- a/docs/source/pyplots/guides/10min_all_sections_strat.py
+++ b/docs/source/pyplots/guides/10min_all_sections_strat.py
@@ -1,10 +1,13 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+import deltametrics as dm
+import matplotlib.pyplot as plt
 
-fig, ax = plt.subplots(7, 1, sharex=True, figsize=(6, 8))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta', dz=0.05)
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+
+fig, ax = plt.subplots(5, 1, sharex=True, figsize=(6, 8))
 ax = ax.flatten()
-for i, var in enumerate(['time'] + rcm8cube.dataio.known_variables):
-    rcm8cube.show_section('demo', var, data='stratigraphy',
-                          ax=ax[i])
+for i, var in enumerate(['time', 'eta', 'velocity', 'discharge', 'sandfrac']):
+    golfcube.show_section('demo', var, data='stratigraphy',
+                          ax=ax[i], label=True)
 plt.show()

--- a/docs/source/pyplots/guides/10min_three_plans.py
+++ b/docs/source/pyplots/guides/10min_three_plans.py
@@ -1,8 +1,7 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
 
-fig, ax = plt.subplots(1, 3, figsize=(6, 2))
-rcm8cube.show_plan('eta', t=40, ax=ax[0])
-rcm8cube.show_plan('velocity', t=40, ax=ax[1], ticks=True)
-rcm8cube.show_plan('strata_sand_frac', t=40, ax=ax[2])
+fig, ax = plt.subplots(1, 3, figsize=(10, 3))
+golfcube.show_plan('eta', t=40, ax=ax[0])
+golfcube.show_plan('velocity', t=40, ax=ax[1], ticks=True)
+golfcube.show_plan('sandfrac', t=40, ax=ax[2])
 plt.show()

--- a/docs/source/pyplots/guides/userguide_1d_example.py
+++ b/docs/source/pyplots/guides/userguide_1d_example.py
@@ -1,6 +1,6 @@
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 
-ets = rcm8cube['eta'].data[:, 25, 120]  # a "real" slice of the model
+ets = golfcube['eta'].data[:, 10, 85]  # a "real" slice of the model
 
 fig, ax = plt.subplots(figsize=(8, 4))
 dm.plot.show_one_dimensional_trajectory_to_strata(ets, ax=ax, dz=0.25)

--- a/docs/source/pyplots/guides/userguide_all_vars_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_all_vars_stratigraphy.py
@@ -1,10 +1,10 @@
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 
-sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-sc8cube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+stratcube.register_section('demo', dm.section.StrikeSection(y=10))
 
-fig, ax = plt.subplots(7, 1, sharex=True, sharey=True, figsize=(12, 9))
+fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 9))
 ax = ax.flatten()
-for i, var in enumerate(['time'] + sc8cube.dataio.known_variables):
-    sc8cube.show_section('demo', var, ax=ax[i], label=True,
-                         style='shaded', data='stratigraphy')
+for i, var in enumerate(['time', 'eta', 'velocity', 'discharge', 'sandfrac']):
+    stratcube.show_section('demo', var, ax=ax[i], label=True,
+                           style='shaded', data='stratigraphy')

--- a/docs/source/pyplots/guides/userguide_bed_elevation_change.py
+++ b/docs/source/pyplots/guides/userguide_bed_elevation_change.py
@@ -1,10 +1,10 @@
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 
 nt = 5
-ts = np.linspace(0, rcm8cube['eta'].shape[0]-1, num=nt, dtype=np.int)
+ts = np.linspace(0, golfcube['eta'].shape[0]-1, num=nt, dtype=np.int)
 
 # compute the change in bed elevation between the last two intervals above
-diff_time = rcm8cube['eta'].data[ts[-1], ...] - rcm8cube['eta'].data[ts[-2], ...]
+diff_time = golfcube['eta'].data[ts[-1], ...] - golfcube['eta'].data[ts[-2], ...]
 fig, ax = plt.subplots(figsize=(5, 3))
 im = ax.imshow(diff_time, cmap='RdBu',
                vmax=abs(diff_time).max(),

--- a/docs/source/pyplots/guides/userguide_bed_timeseries.py
+++ b/docs/source/pyplots/guides/userguide_bed_timeseries.py
@@ -1,11 +1,11 @@
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 
 nt = 5
-ts = np.linspace(0, rcm8cube['eta'].shape[0]-1, num=nt, dtype=np.int)
+ts = np.linspace(0, golfcube['eta'].shape[0]-1, num=nt, dtype=np.int)
 
 fig, ax = plt.subplots(1, nt, figsize=(12, 2))
 for i, t in enumerate(ts):
-    ax[i].imshow(rcm8cube['eta'].data[t, :, :], vmin=-5, vmax=0.5)
+    ax[i].imshow(golfcube['eta'].data[t, :, :], vmin=-2, vmax=0.5)
     ax[i].set_title('t = ' + str(t))
     ax[i].axes.get_xaxis().set_ticks([])
     ax[i].axes.get_yaxis().set_ticks([])

--- a/docs/source/pyplots/guides/userguide_compare_slices.py
+++ b/docs/source/pyplots/guides/userguide_compare_slices.py
@@ -1,10 +1,10 @@
 import matplotlib.gridspec as gs
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
-sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-sc8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+stratcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 fig, ax = plt.subplots(1, 2, figsize=(8, 2))
-rcm8cube.sections['demo'].show('velocity', ax=ax[0])
-sc8cube.sections['demo'].show('velocity', ax=ax[1])
+golfcube.sections['demo'].show('velocity', ax=ax[0])
+stratcube.sections['demo'].show('velocity', ax=ax[1])

--- a/docs/source/pyplots/guides/userguide_frozen_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_frozen_stratigraphy.py
@@ -1,19 +1,19 @@
 import matplotlib.gridspec as gs
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
-sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-sc8cube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+stratcube.register_section('demo', dm.section.StrikeSection(y=10))
 
-fs = sc8cube.export_frozen_variable('strata_sand_frac')
-fe = sc8cube.Z  # exported volume does not have coordinate information!
+fs = stratcube.export_frozen_variable('sandfrac')
+fe = stratcube.Z  # exported volume does not have coordinate information!
 
 fig, ax = plt.subplots(figsize=(10, 2))
 pcm = ax.pcolormesh(np.tile(np.arange(fs.shape[2]), (fs.shape[0], 1)),
                     fe[:, 10, :], fs[:, 10, :], shading='auto',
-                    cmap=rcm8cube.varset['strata_sand_frac'].cmap,
-                    vmin=rcm8cube.varset['strata_sand_frac'].vmin,
-                    vmax=rcm8cube.varset['strata_sand_frac'].vmax)
+                    cmap=golfcube.varset['sandfrac'].cmap,
+                    vmin=golfcube.varset['sandfrac'].vmin,
+                    vmax=golfcube.varset['sandfrac'].vmax)
 dm.plot.append_colorbar(pcm, ax)

--- a/docs/source/pyplots/guides/userguide_quick_stratigraphy_all_variables.py
+++ b/docs/source/pyplots/guides/userguide_quick_stratigraphy_all_variables.py
@@ -1,10 +1,10 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 
-fig, ax = plt.subplots(7, 1, sharex=True, sharey=True, figsize=(12, 12))
+fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 12))
 ax = ax.flatten()
-for i, var in enumerate(['time'] + rcm8cube.dataio.known_variables):
-    rcm8cube.show_section('demo', var, ax=ax[i], label=True,
+for i, var in enumerate(['time', 'eta', 'velocity', 'discharge', 'sandfrac']):
+    golfcube.show_section('demo', var, ax=ax[i], label=True,
                           style='shaded', data='stratigraphy')

--- a/docs/source/pyplots/guides/userguide_quick_stratigraphy_sections.py
+++ b/docs/source/pyplots/guides/userguide_quick_stratigraphy_sections.py
@@ -1,11 +1,11 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 
 fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 8))
-rcm8cube.show_section('demo', 'velocity', ax=ax[0])
-rcm8cube.show_section('demo', 'velocity',
+golfcube.show_section('demo', 'velocity', ax=ax[0])
+golfcube.show_section('demo', 'velocity',
                       data='preserved', ax=ax[1])
-rcm8cube.show_section('demo', 'velocity',
+golfcube.show_section('demo', 'velocity',
                       data='stratigraphy', ax=ax[2])

--- a/docs/source/pyplots/guides/userguide_section_type_demos.py
+++ b/docs/source/pyplots/guides/userguide_section_type_demos.py
@@ -1,22 +1,24 @@
 import matplotlib.gridspec as gs
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
-_strike = dm.section.StrikeSection(rcm8cube, y=18)
-__path = np.column_stack((np.linspace(50, 150, num=4000, dtype=np.int),
-                          np.linspace(10, 90, num=4000, dtype=np.int)))
-_path = dm.section.PathSection(rcm8cube, path=__path)
+_strike = dm.section.StrikeSection(golfcube, y=18)
+__path = np.column_stack((np.linspace(50, 150, num=4000, dtype=int),
+                          np.linspace(10, 90, num=4000, dtype=int)))
+_path = dm.section.PathSection(golfcube, path=__path)
+_circular = dm.section.CircularSection(golfcube, radius=40)
+_rad = dm.section.RadialSection(golfcube, azimuth=70)
 
 fig = plt.figure(constrained_layout=True, figsize=(10, 8))
-spec = gs.GridSpec(ncols=2, nrows=3, figure=fig)
+spec = gs.GridSpec(ncols=2, nrows=3, figure=fig, wspace=0.2, hspace=0.2)
 ax0 = fig.add_subplot(spec[0, :])
 axs = [fig.add_subplot(spec[i, j]) for i, j in zip(
     np.repeat(np.arange(1, 3), 2), np.tile(np.arange(2), (3,)))]
 
-rcm8cube.show_plan('eta', t=-1, ax=ax0, ticks=True)
-for i, s in enumerate([_strike, _path]):
-    ax0.plot(s.trace[:, 0], s.trace[:, 1], 'r--')
+golfcube.show_plan('eta', t=-1, ax=ax0, ticks=True)
+for i, s in enumerate([_strike, _path, _circular, _rad]):
+    s.show_trace('--', ax=ax0)
     s.show('velocity', ax=axs[i])
     axs[i].set_title(s.section_type)

--- a/docs/source/pyplots/guides/userguide_stratigraphy_planform_slice.py
+++ b/docs/source/pyplots/guides/userguide_stratigraphy_planform_slice.py
@@ -1,9 +1,9 @@
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 
-sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-sc8cube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+stratcube.register_section('demo', dm.section.StrikeSection(y=10))
 
-elev_idx = (np.abs(sc8cube.z - -2)).argmin()  # find nearest idx to -2 m
+elev_idx = (np.abs(stratcube.z - -2)).argmin()  # find nearest idx to -2 m
 
 fig, ax = plt.subplots(figsize=(5, 3))
-sc8cube.show_plan('strata_sand_frac', elev_idx, ticks=True)
+stratcube.show_plan('sandfrac', elev_idx, ticks=True)

--- a/docs/source/pyplots/guides/userguide_strikesection_location.py
+++ b/docs/source/pyplots/guides/userguide_strikesection_location.py
@@ -1,8 +1,7 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
-
+golfcube = dm.sample_data.golf()
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 fig, ax = plt.subplots(figsize=(5, 3))
-rcm8cube.show_plan('eta', t=-1, ax=ax, ticks=True)
-ax.plot(rcm8cube.sections['demo'].trace[:, 0],
-        rcm8cube.sections['demo'].trace[:, 1], 'r--')
+golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)
+ax.plot(golfcube.sections['demo'].trace[:, 0],
+        golfcube.sections['demo'].trace[:, 1], 'r--')

--- a/docs/source/pyplots/guides/userguide_three_spacetime_sections.py
+++ b/docs/source/pyplots/guides/userguide_three_spacetime_sections.py
@@ -1,7 +1,7 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 6))
-rcm8cube.show_section('demo', 'eta', ax=ax[0])
-rcm8cube.show_section('demo', 'velocity', ax=ax[1])
-rcm8cube.show_section('demo', 'strata_sand_frac', ax=ax[2])
+golfcube.show_section('demo', 'eta', ax=ax[0])
+golfcube.show_section('demo', 'velocity', ax=ax[1])
+golfcube.show_section('demo', 'sandfrac', ax=ax[2])

--- a/docs/source/pyplots/guides/userguide_three_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_three_stratigraphy.py
@@ -1,16 +1,16 @@
 import matplotlib.gridspec as gs
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
-sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-sc8cube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+stratcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 fig, ax = plt.subplots(3, 1, sharex=True, sharey=True, figsize=(12, 6))
-rcm8cube.sections['demo'].show('time', style='lines',
+golfcube.sections['demo'].show('time', style='lines',
                                data='stratigraphy',
                                ax=ax[0], label=True)
-sc8cube.sections['demo'].show('time', ax=ax[1])
-rcm8cube.sections['demo'].show('time', data='stratigraphy',
+stratcube.sections['demo'].show('time', ax=ax[1])
+golfcube.sections['demo'].show('time', data='stratigraphy',
                                ax=ax[2])

--- a/docs/source/pyplots/guides/visualization_datacube_section_display_style.py
+++ b/docs/source/pyplots/guides/visualization_datacube_section_display_style.py
@@ -1,19 +1,19 @@
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 fig, ax = plt.subplots(3, 2, sharex=True, figsize=(8, 6))
 _v = 'velocity'
-rcm8cube.sections['demo'].show(
+golfcube.sections['demo'].show(
     _v, style='lines', data='spacetime', ax=ax[0, 0])
-rcm8cube.sections['demo'].show(
+golfcube.sections['demo'].show(
     _v, style='shaded', data='spacetime', ax=ax[0, 1])
-rcm8cube.sections['demo'].show(
+golfcube.sections['demo'].show(
     _v, style='lines', data='preserved', ax=ax[1, 0])
-rcm8cube.sections['demo'].show(
+golfcube.sections['demo'].show(
     _v, style='shaded', data='preserved', ax=ax[1, 1])
-rcm8cube.sections['demo'].show(
+golfcube.sections['demo'].show(
     _v, style='lines', data='stratigraphy', ax=ax[2, 0])
-rcm8cube.sections['demo'].show(
+golfcube.sections['demo'].show(
     _v, style='shaded', data='stratigraphy', ax=ax[2, 1])
 plt.show(block=False)

--- a/docs/source/pyplots/mask/centerlinemask.py
+++ b/docs/source/pyplots/mask/centerlinemask.py
@@ -3,8 +3,8 @@ import deltametrics as dm
 from deltametrics.mask import ChannelMask
 from deltametrics.mask import CenterlineMask
 
-rcm8cube = dm.sample_data.rcm8()
-channel_mask = ChannelMask(rcm8cube['velocity'].data[-1, :, :],
-                           rcm8cube['eta'].data[-1, :, :])
+golfcube = dm.sample_data.golf()
+channel_mask = ChannelMask(golfcube['velocity'].data[-1, :, :],
+                           golfcube['eta'].data[-1, :, :])
 centerline_mask = CenterlineMask(channel_mask)
 centerline_mask.show()

--- a/docs/source/pyplots/mask/channelmask.py
+++ b/docs/source/pyplots/mask/channelmask.py
@@ -2,7 +2,7 @@
 import deltametrics as dm
 from deltametrics.mask import ChannelMask
 
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 channel_mask = ChannelMask(rcm8cube['velocity'].data[-1, :, :],
                            rcm8cube['eta'].data[-1, :, :])
 channel_mask.show()

--- a/docs/source/pyplots/mask/edgemask.py
+++ b/docs/source/pyplots/mask/edgemask.py
@@ -2,6 +2,6 @@
 import deltametrics as dm
 from deltametrics.mask import EdgeMask
 
-rcm8cube = dm.sample_data.rcm8()
-edge_mask = EdgeMask(rcm8cube['eta'].data[-1, :, :])
+golfcube = dm.sample_data.golf()
+edge_mask = EdgeMask(golfcube['eta'].data[-1, :, :])
 edge_mask.show()

--- a/docs/source/pyplots/mask/landmask.py
+++ b/docs/source/pyplots/mask/landmask.py
@@ -2,6 +2,6 @@
 import deltametrics as dm
 from deltametrics.mask import LandMask
 
-rcm8cube = dm.sample_data.rcm8()
-land_mask = LandMask(rcm8cube['eta'].data[-1, :, :])
+golfcube = dm.sample_data.golf()
+land_mask = LandMask(golfcube['eta'].data[-1, :, :])
 land_mask.show()

--- a/docs/source/pyplots/mask/shoremask.py
+++ b/docs/source/pyplots/mask/shoremask.py
@@ -2,6 +2,6 @@
 import deltametrics as dm
 from deltametrics.mask import ShorelineMask
 
-rcm8cube = dm.sample_data.rcm8()
-shore_mask = ShorelineMask(rcm8cube['eta'].data[-1, :, :])
+golfcube = dm.sample_data.golf()
+shore_mask = ShorelineMask(golfcube['eta'].data[-1, :, :])
 shore_mask.show()

--- a/docs/source/pyplots/mask/wetmask.py
+++ b/docs/source/pyplots/mask/wetmask.py
@@ -2,6 +2,6 @@
 import deltametrics as dm
 from deltametrics.mask import WetMask
 
-rcm8cube = dm.sample_data.rcm8()
-wet_mask = WetMask(rcm8cube['eta'].data[-1, :, :])
+golfcube = dm.sample_data.golf()
+wet_mask = WetMask(golfcube['eta'].data[-1, :, :])
 wet_mask.show()

--- a/docs/source/pyplots/section/section_demo_quick_strat.py
+++ b/docs/source/pyplots/section/section_demo_quick_strat.py
@@ -2,16 +2,16 @@ import matplotlib.pyplot as plt
 
 import deltametrics as dm
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=5))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=5))
 
 fig, ax = plt.subplots(4, 1, sharex=True, figsize=(8, 6))
-rcm8cube.sections['demo'].show('depth', data='spacetime',
+golfcube.sections['demo'].show('depth', data='spacetime',
                                ax=ax[0], label='spacetime')
-rcm8cube.sections['demo'].show('depth', data='preserved',
+golfcube.sections['demo'].show('depth', data='preserved',
                                ax=ax[1], label='preserved')
-rcm8cube.sections['demo'].show('depth', data='stratigraphy',
+golfcube.sections['demo'].show('depth', data='stratigraphy',
                                ax=ax[2], label='quick stratigraphy')
-rcm8cube.sections['demo'].show('depth', style='lines', data='stratigraphy',
+golfcube.sections['demo'].show('depth', style='lines', data='stratigraphy',
                                ax=ax[3], label='quick stratigraphy')

--- a/docs/source/pyplots/section/section_demo_spacetime.py
+++ b/docs/source/pyplots/section/section_demo_spacetime.py
@@ -2,9 +2,9 @@ import matplotlib.pyplot as plt
 
 import deltametrics as dm
 
-rcm8cube = dm.sample_data.rcm8()
+golfcube = dm.sample_data.golf()
 
 
 fig, ax = plt.subplots(figsize=(8, 2))
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=5))
-rcm8cube.sections['demo'].show('velocity')
+golfcube.register_section('demo', dm.section.StrikeSection(y=5))
+golfcube.sections['demo'].show('velocity')

--- a/docs/source/pyplots/section/section_lexicon.py
+++ b/docs/source/pyplots/section/section_lexicon.py
@@ -2,18 +2,18 @@ import matplotlib.pyplot as plt
 
 import deltametrics as dm
 
-rcm8cube = dm.sample_data.rcm8()
-rcm8cube.stratigraphy_from('eta')
-rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube = dm.sample_data.golf()
+golfcube.stratigraphy_from('eta')
+golfcube.register_section('demo', dm.section.StrikeSection(y=10))
 
 fig, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 3.5))
 
-ax[0].imshow(rcm8cube.sections['demo']['velocity'],
-             origin='lower', cmap=rcm8cube.varset['velocity'].cmap)
+ax[0].imshow(golfcube.sections['demo']['velocity'],
+             origin='lower', cmap=golfcube.varset['velocity'].cmap)
 ax[0].set_ylabel('$t$ coordinate')
 
-ax[1].imshow(rcm8cube.sections['demo']['velocity'].as_preserved(),
-             origin='lower', cmap=rcm8cube.varset['velocity'].cmap)
+ax[1].imshow(golfcube.sections['demo']['velocity'].as_preserved(),
+             origin='lower', cmap=golfcube.varset['velocity'].cmap)
 ax[1].set_ylabel('$t$ coordinate')
 
 ax[1].set_xlabel('$s$ coordinate')

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -26,7 +26,9 @@ class TestOpeningAnglePlanform:
     simple_ocean = (1 - simple_land)
 
     golf_path = _get_golf_path()
-    golfcube = cube.DataCube(golf_path)
+    golfcube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
 
     def test_defaults_array_int(self):
 
@@ -104,7 +106,9 @@ class TestMorphologicalPlanform:
 
     simple_land = simple_land
     golf_path = _get_golf_path()
-    golfcube = cube.DataCube(golf_path)
+    golfcube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
 
     def test_defaults_array_int(self):
         mpm = plan.MorphologicalPlanform(self.simple_land.astype(int), 2)
@@ -335,7 +339,9 @@ class TestShorelineLength:
 class TestShorelineDistance:
 
     golf_path = _get_golf_path()
-    golf = cube.DataCube(golf_path)
+    golf = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
 
     sm = mask.ShorelineMask(
         golf['eta'][-1, :, :],
@@ -391,7 +397,9 @@ class TestComputeChannelWidth:
         ).astype(int)
 
     golf_path = _get_golf_path()
-    golf = cube.DataCube(golf_path)
+    golf = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
 
     cm = mask.ChannelMask(
         golf['eta'][-1, :, :],
@@ -468,7 +476,9 @@ class TestComputeChannelDepth:
         ).astype(int)
 
     golf_path = _get_golf_path()
-    golf = cube.DataCube(golf_path)
+    golf = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
 
     cm = mask.ChannelMask(
         golf['eta'][-1, :, :],

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -39,16 +39,20 @@ class TestStrikeSection:
             _ = section.StrikeSection(badcube, y=12)
 
     def test_StrikeSection_standalone_instantiation(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         sass = section.StrikeSection(rcm8cube, y=12)
         assert sass.name == 'strike'
         assert sass.y == 12
         assert sass.cube == rcm8cube
-        assert sass.trace.shape == (240, 2)
+        assert sass.trace.shape == (rcm8cube.shape[2], 2)
         assert len(sass.variables) > 0
 
     def test_StrikeSection_register_section(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section('test', section.StrikeSection(y=5))
         assert rcm8cube.sections['test'].name == 'test'
         assert len(rcm8cube.sections['test'].variables) > 0
@@ -62,7 +66,9 @@ class TestStrikeSection:
         assert isinstance(_sect, section.StrikeSection)
 
     def test_StrikeSection_register_section_x_limits(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section('tuple', section.StrikeSection(y=5,
                                                                  x=(10, 110)))
         rcm8cube.register_section('list', section.StrikeSection(y=5,
@@ -77,8 +83,8 @@ class TestStrikeSection:
 class TestPathSection:
     """Test the basic of the PathSection."""
 
-    test_path = np.column_stack((np.arange(10, 110, 20),
-                                 np.arange(50, 150, 20)))
+    test_path = np.column_stack((np.arange(60, 120, 20),   # x column
+                                 np.arange(5, 65, 20)))  # y column
 
     def test_without_cube(self):
         ps = section.PathSection(path=self.test_path)
@@ -100,7 +106,9 @@ class TestPathSection:
             _ = section.PathSection(badcube, path=self.test_path)
 
     def test_standalone_instantiation(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         saps = section.PathSection(rcm8cube, path=self.test_path)
         assert saps.name == 'path'
         assert saps.cube == rcm8cube
@@ -109,7 +117,9 @@ class TestPathSection:
         assert len(saps.variables) > 0
 
     def test_register_section(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.stratigraphy_from('eta')
         rcm8cube.register_section(
             'test', section.PathSection(path=self.test_path))
@@ -129,7 +139,9 @@ class TestPathSection:
 
     def test_return_path(self):
         # test that returned path and trace are the same
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         saps = section.PathSection(rcm8cube, path=self.test_path)
         _t = saps.trace
         _p = saps.path
@@ -137,12 +149,14 @@ class TestPathSection:
 
     def test_path_reduced_unique(self):
         # test a first case with a straight line
-        rcm8cube = cube.DataCube(rcm8_path)
-        xy = np.column_stack((np.linspace(50, 150, num=4000, dtype=int),
-                              np.linspace(10, 90, num=4000, dtype=int)))
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
+        xy = np.column_stack((np.linspace(150, 50, num=4000, dtype=int),
+                              np.linspace(90, 10, num=4000, dtype=int)))
         saps1 = section.PathSection(rcm8cube, path=xy)
         assert saps1.path.shape != xy.shape
-        assert np.all(saps1.path == np.unique(xy, axis=0))
+        assert np.all(saps1._xytrace == np.unique(xy, axis=0))
 
         # test a second case with small line to ensure non-unique removed
         saps2 = section.PathSection(rcm8cube, path=np.array([[50, 25],
@@ -174,7 +188,9 @@ class TestCircularSection:
             _ = section.CircularSection(badcube, radius=30)
 
     def test_standalone_instantiation(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         sacs = section.CircularSection(rcm8cube, radius=30)
         assert sacs.name == 'circular'
         assert sacs.cube == rcm8cube
@@ -188,7 +204,9 @@ class TestCircularSection:
         assert sacs2.origin == (10, 0)
 
     def test_standalone_instantiation_withmeta(self):
-        golfcube = cube.DataCube(golf_path)
+        golfcube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         sacs = section.CircularSection(golfcube, radius=30)
         assert sacs.name == 'circular'
         assert sacs.cube == golfcube
@@ -208,7 +226,9 @@ class TestCircularSection:
         assert sacs3.radius == 1
 
     def test_register_section(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.stratigraphy_from('eta')
         rcm8cube.register_section(
             'test', section.CircularSection(radius=30))
@@ -220,22 +240,24 @@ class TestCircularSection:
             assert rcm8cube.sections['test2'].name == 'different'
         rcm8cube.register_section(
             'test3', section.CircularSection())
-        assert rcm8cube.sections['test3'].radius == 60
+        assert rcm8cube.sections['test3'].radius == rcm8cube.shape[1] // 2
         _section = rcm8cube.register_section(
             'test3', section.CircularSection(), return_section=True)
         assert isinstance(_section, section.CircularSection)
 
     def test_all_idx_reduced_unique(self):
         # we try this for a bunch of different radii
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         sacs1 = section.CircularSection(rcm8cube, radius=40)
-        assert len(sacs1.trace) == len(np.unique(sacs1.trace, axis=0))
-        sacs2 = section.CircularSection(rcm8cube, radius=2334)
-        assert len(sacs2.trace) == len(np.unique(sacs2.trace, axis=0))
-        sacs3 = section.CircularSection(rcm8cube, radius=167)
-        assert len(sacs3.trace) == len(np.unique(sacs3.trace, axis=0))
+        assert len(sacs1._xytrace) == len(np.unique(sacs1._xytrace, axis=0))
+        sacs2 = section.CircularSection(rcm8cube, radius=23)
+        assert len(sacs2._xytrace) == len(np.unique(sacs2._xytrace, axis=0))
+        sacs3 = section.CircularSection(rcm8cube, radius=17)
+        assert len(sacs3._xytrace) == len(np.unique(sacs3._xytrace, axis=0))
         sacs4 = section.CircularSection(rcm8cube, radius=33)
-        assert len(sacs4.trace) == len(np.unique(sacs4.trace, axis=0))
+        assert len(sacs4._xytrace) == len(np.unique(sacs4._xytrace, axis=0))
 
 
 class TestRadialSection:
@@ -271,23 +293,29 @@ class TestRadialSection:
             _ = section.RadialSection(badcube, azimuth=30)
 
     def test_standalone_instantiation(self):
-        rcm8cube = cube.DataCube(rcm8_path)
-        sars = section.RadialSection(rcm8cube)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
+        sars = section.RadialSection(
+            rcm8cube)
         assert sars.name == 'radial'
         assert sars.cube == rcm8cube
-        assert sars.trace.shape[0] == 117  # 120 - L0 = 120 - 3
+        assert sars.trace.shape[0] == rcm8cube.shape[1] - rcm8cube.meta['L0']  # 120 - L0 = 120 - 3
         assert len(sars.variables) > 0
         assert sars.azimuth == 90
-        sars1 = section.RadialSection(rcm8cube, azimuth=30)
+        sars1 = section.RadialSection(
+            rcm8cube, azimuth=30)
         assert sars1.name == 'radial'
         assert sars1.cube == rcm8cube
-        assert sars1.trace.shape[0] == 120
+        assert sars1.trace.shape[0] == rcm8cube.shape[1]
         assert len(sars1.variables) > 0
         assert sars1.azimuth == 30
-        sars2 = section.RadialSection(rcm8cube, azimuth=103, origin=(90, 2))
+        sars2_starty = 2
+        sars2 = section.RadialSection(
+            rcm8cube, azimuth=103, origin=(90, sars2_starty))
         assert sars2.name == 'radial'
         assert sars2.cube == rcm8cube
-        assert sars2.trace.shape[0] == 118
+        assert sars2.trace.shape[0] == rcm8cube.shape[1] - sars2_starty
         assert len(sars2.variables) > 0
         assert sars2.azimuth == 103
         assert sars2.origin == (90, 2)
@@ -301,7 +329,9 @@ class TestRadialSection:
         assert sars3.origin == (143, 18)
 
     def test_standalone_instantiation_withmeta(self):
-        golfcube = cube.DataCube(golf_path)
+        golfcube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         sars = section.RadialSection(golfcube)
         assert sars.origin[1] == golfcube.meta['L0']
         sars1 = section.RadialSection(golfcube, azimuth=30)
@@ -314,7 +344,9 @@ class TestRadialSection:
         assert sars3.origin == (143, 18)
 
     def test_register_section(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section(
             'test', section.RadialSection(azimuth=30))
         assert len(rcm8cube.sections['test'].variables) > 0
@@ -332,43 +364,46 @@ class TestRadialSection:
         assert _section2 is None
 
     def test_autodetect_origin_range_aziumths(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section(
             'test', section.RadialSection(azimuth=0))
+        _cshp = rcm8cube.shape
         assert isinstance(rcm8cube.sections['test'], section.RadialSection)
-        assert rcm8cube.sections['test'].trace.shape[0] == 120
-        assert rcm8cube.sections['test']._x[-1] == 239
+        assert rcm8cube.sections['test'].trace.shape[0] == _cshp[2] // 2
+        assert rcm8cube.sections['test']._x[-1] == _cshp[2] - 1
         assert rcm8cube.sections['test']._y[-1] == 3
-        assert rcm8cube.sections['test']['velocity'].shape == (51, 120)
+        assert rcm8cube.sections['test']['velocity'].shape == (_cshp[0], _cshp[1])
         rcm8cube.register_section(
             'test2', section.RadialSection(azimuth=45))
         assert isinstance(rcm8cube.sections['test2'], section.RadialSection)
-        assert rcm8cube.sections['test2'].trace.shape[0] == 120
-        assert rcm8cube.sections['test2']._x[-1] == 239
-        assert rcm8cube.sections['test2']._y[-1] == 119
-        assert rcm8cube.sections['test2']['velocity'].shape == (51, 120)
+        assert rcm8cube.sections['test2'].trace.shape[0] == _cshp[1]
+        assert rcm8cube.sections['test2']._x[-1] == _cshp[2] - 1
+        assert rcm8cube.sections['test2']._y[-1] == _cshp[1] - 1
+        assert rcm8cube.sections['test2']['velocity'].shape == (_cshp[0], _cshp[1])
         rcm8cube.register_section(
             'test3', section.RadialSection(azimuth=85))
         assert isinstance(rcm8cube.sections['test3'], section.RadialSection)
-        assert rcm8cube.sections['test3'].trace.shape[0] == 117
-        assert rcm8cube.sections['test3']._x[-1] == 130
-        assert rcm8cube.sections['test3']._y[-1] == 119
-        assert rcm8cube.sections['test3']['velocity'].shape == (51, 117)
+        assert rcm8cube.sections['test3'].trace.shape[0] < _cshp[1]  # slight oblique
+        assert rcm8cube.sections['test3']._x[-1] > _cshp[2] // 2  # slight oblique
+        assert rcm8cube.sections['test3']._y[-1] == _cshp[1] - 1  # slight oblique
+        assert rcm8cube.sections['test3']['velocity'].shape[0] == _cshp[0]
         rcm8cube.register_section(
             'test4', section.RadialSection(azimuth=115))
         assert isinstance(rcm8cube.sections['test4'], section.RadialSection)
-        assert rcm8cube.sections['test4'].trace.shape[0] == 117
-        assert rcm8cube.sections['test4']._x[-1] == 65
-        assert rcm8cube.sections['test4']._y[-1] == 119
-        assert rcm8cube.sections['test4']['velocity'].shape == (51, 117)
+        assert rcm8cube.sections['test4'].trace.shape[0] < _cshp[1]  # slight oblique
+        assert rcm8cube.sections['test4']._x[-1] < _cshp[2] // 2  # slight oblique
+        assert rcm8cube.sections['test4']._y[-1] == _cshp[1] - 1  # slight oblique
+        assert rcm8cube.sections['test4']['velocity'].shape[0] == _cshp[0]
         rcm8cube.register_section(
             'test5', section.RadialSection(azimuth=165))
         assert isinstance(rcm8cube.sections['test5'], section.RadialSection)
-        assert rcm8cube.sections['test5'].trace.shape[0] == 121
-        assert rcm8cube.sections['test5']._x[-1] == 120
+        assert rcm8cube.sections['test5'].trace.shape[0] > _cshp[1]  # obtuse
+        assert rcm8cube.sections['test5']._x[-1] == _cshp[1]
         assert rcm8cube.sections['test5']._x[0] == 0
-        assert rcm8cube.sections['test5']._y[-1] == 3
-        assert rcm8cube.sections['test5']['velocity'].shape == (51, 121)
+        assert rcm8cube.sections['test5']._y[-1] == 2  # this should change if sorting fixed?
+        assert rcm8cube.sections['test5']['velocity'].shape[0] == _cshp[0]
         with pytest.raises(ValueError, match=r'Azimuth must be *.'):
             rcm8cube.register_section(
                 'testfail', section.RadialSection(azimuth=-10))
@@ -377,7 +412,9 @@ class TestRadialSection:
                 'testfail', section.RadialSection(azimuth=190))
 
     def test_specify_origin_and_azimuth(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section(
             'test', section.RadialSection(azimuth=145, origin=(20, 3)))
         assert isinstance(rcm8cube.sections['test'], section.RadialSection)
@@ -390,10 +427,15 @@ class TestRadialSection:
 
 class TestCubesWithManySections:
 
-    rcm8cube = cube.DataCube(rcm8_path)
-    sc8cube = cube.StratigraphyCube.from_DataCube(rcm8cube)
-    test_path = np.column_stack((np.arange(10, 110, 2),
-                                 np.arange(50, 150, 2)))
+    rcm8cube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
+    sc8cube = cube.StratigraphyCube.from_DataCube(
+        rcm8cube,
+        dz=0.1)
+    #                     [x, y]
+    test_path = np.array([[120, 60],
+                          [40, 30]])
 
     def test_data_equivalence(self):
         assert self.rcm8cube.dataio is self.sc8cube.dataio
@@ -447,7 +489,9 @@ class TestCubesWithManySections:
 # Cubes and strat
 class TestSectionFromDataCubeNoStratigraphy:
 
-    rcm8cube_nostrat = cube.DataCube(rcm8_path)
+    rcm8cube_nostrat = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
     rcm8cube_nostrat.register_section('test', section.StrikeSection(y=5))
 
     def test_nostrat_getitem_explicit(self):
@@ -467,7 +511,9 @@ class TestSectionFromDataCubeNoStratigraphy:
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass['velocity']
         # make a good section, then switch to invalidcube inside section
-        temp_rcm8cube_nostrat = cube.DataCube(rcm8_path)
+        temp_rcm8cube_nostrat = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         temp_rcm8cube_nostrat.register_section(
             'test', section.StrikeSection(y=5))
         temp_rcm8cube_nostrat.sections['test'].cube = 'badvalue!'
@@ -579,8 +625,10 @@ class TestSectionFromDataCubeNoStratigraphy:
 
 class TestSectionFromDataCubeWithStratigraphy:
 
-    rcm8cube = cube.DataCube(rcm8_path)
-    rcm8cube.stratigraphy_from('eta')
+    rcm8cube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
+    rcm8cube.stratigraphy_from('eta', dz=0.1)
     rcm8cube.register_section('test', section.StrikeSection(y=5))
 
     def test_withstrat_getitem_explicit(self):
@@ -600,7 +648,9 @@ class TestSectionFromDataCubeWithStratigraphy:
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass['velocity']
         # make a good section, then switch to invalidcube inside section
-        temp_rcm8cube = cube.DataCube(rcm8_path)
+        temp_rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         temp_rcm8cube.register_section('test', section.StrikeSection(y=5))
         temp_rcm8cube.sections['test'].cube = 'badvalue!'
         with pytest.raises(TypeError):
@@ -633,8 +683,8 @@ class TestSectionFromDataCubeWithStratigraphy:
         assert isinstance(_v, list)
 
     def test_withstrat_registered_StrikeSection_attributes(self):
-        assert np.all(self.rcm8cube.sections['test'].trace[:, 1] == 5)
-        assert self.rcm8cube.sections['test'].s.size == 240
+        assert np.all(self.rcm8cube.sections['test']._xytrace[:, 1] == 5)
+        assert self.rcm8cube.sections['test'].s.size == self.rcm8cube.shape[2]
         assert len(self.rcm8cube.sections['test'].variables) > 0
         assert self.rcm8cube.sections['test'].y == 5
 
@@ -655,9 +705,9 @@ class TestSectionFromDataCubeWithStratigraphy:
 
     def test_withstrat_strat_attr_shapes(self):
         sa = self.rcm8cube.sections['test']['velocity'].strat_attr
-        assert sa['x0'].shape == (51, 240)
-        assert sa['x1'].shape == (51, 240)
-        assert sa['s'].shape == (240,)
+        assert sa['x0'].shape == (101, self.rcm8cube.shape[2])
+        assert sa['x1'].shape == (101, self.rcm8cube.shape[2])
+        assert sa['s'].shape == (self.rcm8cube.shape[2],)
         assert sa['s_sp'].shape == sa['z_sp'].shape
 
     def test_withstrat_show_shaded_spacetime(self):
@@ -717,8 +767,11 @@ class TestSectionFromDataCubeWithStratigraphy:
 
 class TestSectionFromStratigraphyCube:
 
-    rcm8cube = cube.DataCube(rcm8_path)
-    sc8cube = cube.StratigraphyCube.from_DataCube(rcm8cube)
+    rcm8cube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
+    sc8cube = cube.StratigraphyCube.from_DataCube(
+        rcm8cube, dz=0.1)
     rcm8cube.register_section('test', section.StrikeSection(y=5))
     sc8cube.register_section('test', section.StrikeSection(y=5))
 
@@ -739,7 +792,9 @@ class TestSectionFromStratigraphyCube:
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass['velocity']
         # make a good section, then switch to invalidcube inside section
-        temp_rcm8cube = cube.DataCube(rcm8_path)
+        temp_rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         temp_rcm8cube.register_section('test', section.StrikeSection(y=5))
         temp_rcm8cube.sections['test'].cube = 'badvalue!'
         with pytest.raises(TypeError):
@@ -754,6 +809,10 @@ class TestSectionFromStratigraphyCube:
     def test_trace(self):
         assert isinstance(self.rcm8cube.sections['test'].trace, np.ndarray)
         assert isinstance(self.sc8cube.sections['test'].trace, np.ndarray)
+
+    def test_xytrace(self):
+        assert isinstance(self.rcm8cube.sections['test']._xytrace, np.ndarray)
+        assert isinstance(self.sc8cube.sections['test']._xytrace, np.ndarray)
 
     def test_s(self):
         assert isinstance(self.rcm8cube.sections['test'].s, np.ndarray)
@@ -836,7 +895,9 @@ class TestSectionFromStratigraphyCube:
 
 class TestDataSectionVariableNoStratigraphy:
 
-    rcm8cube = cube.DataCube(rcm8_path)
+    rcm8cube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
     rcm8cube.register_section('test', section.StrikeSection(y=5))
     dsv = rcm8cube.sections['test']['velocity']
 
@@ -887,8 +948,10 @@ class TestDataSectionVariableNoStratigraphy:
 
 class TestDataSectionVariableWithStratigraphy:
 
-    rcm8cube = cube.DataCube(rcm8_path)
-    rcm8cube.stratigraphy_from('eta')
+    rcm8cube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
+    rcm8cube.stratigraphy_from('eta', dz=0.1)
     rcm8cube.register_section('test', section.StrikeSection(y=5))
     dsv = rcm8cube.sections['test']['velocity']
 
@@ -943,8 +1006,11 @@ class TestDataSectionVariableWithStratigraphy:
 
 class TestStratigraphySectionVariable:
 
-    rcm8cube = cube.DataCube(rcm8_path)
-    sc8cube = cube.StratigraphyCube.from_DataCube(rcm8cube)
+    rcm8cube = cube.DataCube(
+        golf_path,
+        coordinates={'x': 'y', 'y': 'x'})
+    sc8cube = cube.StratigraphyCube.from_DataCube(
+        rcm8cube, dz=0.1)
     sc8cube.register_section('test', section.StrikeSection(y=5))
     ssv = sc8cube.sections['test']['velocity']
 
@@ -1019,16 +1085,20 @@ class TestDipSection:
             _ = section.DipSection(badcube, x=12)
 
     def test_DipSection_standalone_instantiation(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         sass = section.DipSection(rcm8cube, x=120)
         assert sass.name == 'dip'
         assert sass.x == 120
         assert sass.cube == rcm8cube
-        assert sass.trace.shape == (120, 2)
+        assert sass.trace.shape == (rcm8cube.shape[1], 2)
         assert len(sass.variables) > 0
 
     def test_DipSection_register_section(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section('test', section.DipSection(x=150))
         assert rcm8cube.sections['test'].name == 'test'
         assert len(rcm8cube.sections['test'].variables) > 0
@@ -1042,7 +1112,9 @@ class TestDipSection:
         assert isinstance(_sect, section.DipSection)
 
     def test_DipSection_register_section_x_limits(self):
-        rcm8cube = cube.DataCube(rcm8_path)
+        rcm8cube = cube.DataCube(
+            golf_path,
+            coordinates={'x': 'y', 'y': 'x'})
         rcm8cube.register_section('tuple', section.DipSection(x=150,
                                                               y=(10, 50)))
         rcm8cube.register_section('list', section.DipSection(x=150,

--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -63,8 +63,7 @@ class TestComputeBoxyStratigraphyVolume:
                 dz=0.05)
 
     def test_no_z_options(self):
-        with pytest.raises(ValueError,
-                           match=r'You must specify "z", "dz", or "nz.'):
+        with pytest.warns(UserWarning, match=r'No specification .*'):
             strat.compute_boxy_stratigraphy_volume(self.elev, self.time)
 
 
@@ -100,8 +99,7 @@ class TestComputeBoxyStratigraphyCoordinates:
             self.elev, dz=0.05, return_cube=True)
 
     def test_no_z_options(self):
-        with pytest.raises(ValueError,
-                           match=r'You must specify "z", "dz", or "nz.'):
+        with pytest.warns(UserWarning, match=r'No specification .*'):
             strat.compute_boxy_stratigraphy_coordinates(
                 self.elev[:, 10, 120].squeeze())
 
@@ -305,9 +303,9 @@ class TestOneDimStratigraphyExamples:
 
 class TestDetermineStratCoordinates:
 
-    def test_given_none(self):
+    def test_given_none_chooses_default(self):
         e = np.array([0, 1, 1, 2, 1])
-        with pytest.raises(ValueError, match=r'You must *.'):
+        with pytest.warns(UserWarning, match=r'No specification *.'):
             _ = strat._determine_strat_coordinates(e)
 
     def test_given_z(self):


### PR DESCRIPTION
This is an attempt to integrate the new ordering of `x` and `y` from the latest pyDeltaRCM outputs. 

The signature to _correctly_ create a cube from a pyDeltaRCM model output is now:
```
cube.DataCube(golf_path, coordinates={'x': 'y', 'y': 'x'})
```

omitting the coordinates option will return a cube, but the orientation of slicing will be switched. Although a bit clunky, this allows us to flexibly import a netcdf file with arbitrary coordinates and then handle everything internally with a consistent 'x' and 'y'. 

This PR does some parts of integrating the xarray into DeltaMetrics, namely fixing section slicing to use coordinate arrays.