### PR TITLE
Integrate xarray

### DIFF
--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -275,14 +275,14 @@ class BaseSection(abc.ABC):
         Compute the along-section coordinate array from x-y pts pairs
         definining the section.
         """
-        self._s = np.cumsum(np.hstack(
-            (0, np.sqrt((self._x[1:] - self._x[:-1])**2
-             + (self._y[1:] - self._y[:-1])**2))))
-        self._z = self.cube.z
-        self._shape = (len(self._z), len(self._s))
         self._xytrace = np.column_stack((self._x, self._y))
         self._trace = np.column_stack((self.cube.x[self._x],
                                        self.cube.y[self._y]))
+        self._s = np.cumsum(np.hstack(
+            (0, np.sqrt((self._trace[1:, 0] - self._trace[:-1, 0])**2
+             + (self._trace[1:, 1] - self._trace[:-1, 1])**2))))
+        self._z = self.cube.z
+        self._shape = (len(self._z), len(self._s))
 
     @property
     def trace(self):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -3,6 +3,7 @@ import pytest
 import sys
 import os
 import numpy as np
+import xarray as xr
 import matplotlib.pyplot as plt
 
 import unittest.mock as mock
@@ -250,7 +251,7 @@ class TestShorelineMask:
         assert shoremask.mask_type == 'shoreline'
         assert shoremask.contour_threshold > 0
         assert shoremask._mask.dtype == bool
-        assert isinstance(shoremask._mask, np.ndarray)
+        assert isinstance(shoremask._mask, xr.core.dataarray.DataArray)
 
     @pytest.mark.xfail(raises=NotImplementedError, strict=True,
                        reason='Have not implemented pathway.')
@@ -1189,6 +1190,7 @@ class TestChannelMask:
 
         assert np.all(channelmask_comp._mask == mfem2._mask)
         assert np.all(mfem._mask == mfem2._mask)
+        assert isinstance(channelmask_comp._mask, xr.core.dataarray.DataArray)
 
     def test_static_from_masks_LandMask_FlowMask(self):
         channelmask_comp = mask.ChannelMask(
@@ -1646,14 +1648,14 @@ class TestGeometricMask:
         gmsk = mask.GeometricMask(arr)
         gmsk.circular(1, 2, origin=(3, 3))
         assert gmsk._mask[3, 3] == 0
-        assert np.all(gmsk._mask == np.array([[[0., 0., 0., 0., 0., 0., 0.],
-                                               [0., 0., 0., 1., 0., 0., 0.],
-                                               [0., 0., 1., 1., 1., 0., 0.],
-                                               [0., 1., 1., 0., 1., 1., 0.],
-                                               [0., 0., 1., 1., 1., 0., 0.],
-                                               [0., 0., 0., 1., 0., 0., 0.],
-                                               [0., 0., 0., 0., 0., 0., 0.]]])
-                      )
+        assert np.all(gmsk._mask.values == 
+                      np.array([[[0., 0., 0., 0., 0., 0., 0.],
+                                 [0., 0., 0., 1., 0., 0., 0.],
+                                 [0., 0., 1., 1., 1., 0., 0.],
+                                 [0., 1., 1., 0., 1., 1., 0.],
+                                 [0., 0., 1., 1., 1., 0., 0.],
+                                 [0., 0., 0., 1., 0., 0., 0.],
+                                 [0., 0., 0., 0., 0., 0., 0.]]]))
         # check that the Mask origin is different
         #  from the one used in method (3, 3)
         assert gmsk.xc == 0

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -4,6 +4,7 @@ import sys
 import os
 
 import numpy as np
+import xarray as xr
 
 from deltametrics.sample_data import _get_rcm8_path, _get_golf_path
 
@@ -33,14 +34,14 @@ class TestOpeningAnglePlanform:
     def test_defaults_array_int(self):
 
         oap = plan.OpeningAnglePlanform(self.simple_ocean.astype(int))
-        assert isinstance(oap.sea_angles, np.ndarray)
+        assert isinstance(oap.sea_angles, xr.core.dataarray.DataArray)
         assert oap.sea_angles.shape == self.simple_ocean.shape
         assert oap.below_mask.dtype == bool
 
     def test_defaults_array_bool(self):
 
         oap = plan.OpeningAnglePlanform(self.simple_ocean.astype(bool))
-        assert isinstance(oap.sea_angles, np.ndarray)
+        assert isinstance(oap.sea_angles, xr.core.dataarray.DataArray)
         assert oap.sea_angles.shape == self.simple_ocean.shape
         assert oap.below_mask.dtype == bool
 
@@ -60,7 +61,7 @@ class TestOpeningAnglePlanform:
         oap = plan.OpeningAnglePlanform.from_elevation_data(
             self.golfcube['eta'][-1, :, :],
             elevation_threshold=0)
-        assert isinstance(oap.sea_angles, np.ndarray)
+        assert isinstance(oap.sea_angles, xr.core.dataarray.DataArray)
         assert oap.sea_angles.shape == self.golfcube.shape[1:]
         assert oap.below_mask.dtype == bool
 
@@ -78,7 +79,7 @@ class TestOpeningAnglePlanform:
 
         oap = plan.OpeningAnglePlanform.from_ElevationMask(_em)
 
-        assert isinstance(oap.sea_angles, np.ndarray)
+        assert isinstance(oap.sea_angles, xr.core.dataarray.DataArray)
         assert oap.sea_angles.shape == _em.shape
         assert oap.below_mask.dtype == bool
 
@@ -112,7 +113,7 @@ class TestMorphologicalPlanform:
 
     def test_defaults_array_int(self):
         mpm = plan.MorphologicalPlanform(self.simple_land.astype(int), 2)
-        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._mean_image, xr.core.dataarray.DataArray)
         assert isinstance(mpm._all_images, np.ndarray)
         assert mpm._mean_image.shape == self.simple_land.shape
         assert len(mpm._all_images.shape) == 3
@@ -120,7 +121,7 @@ class TestMorphologicalPlanform:
 
     def test_defaults_array_bool(self):
         mpm = plan.MorphologicalPlanform(self.simple_land.astype(bool), 2)
-        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._mean_image, xr.core.dataarray.DataArray)
         assert isinstance(mpm._all_images, np.ndarray)
         assert mpm._mean_image.shape == self.simple_land.shape
         assert len(mpm._all_images.shape) == 3
@@ -128,7 +129,7 @@ class TestMorphologicalPlanform:
 
     def test_defaults_array_float(self):
         mpm = plan.MorphologicalPlanform(self.simple_land.astype(float), 2.0)
-        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._mean_image, xr.core.dataarray.DataArray)
         assert isinstance(mpm._all_images, np.ndarray)
         assert mpm._mean_image.shape == self.simple_land.shape
         assert len(mpm._all_images.shape) == 3
@@ -146,13 +147,13 @@ class TestMorphologicalPlanform:
         assert mpm.planform_type == 'morphological method'
         assert mpm._mean_image.shape == (100, 200)
         assert mpm._all_images.shape == (3, 100, 200)
-        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._mean_image, xr.core.dataarray.DataArray)
         assert isinstance(mpm._all_images, np.ndarray)
 
     def test_static_from_mask(self):
         mpm = plan.MorphologicalPlanform.from_mask(
             self.simple_land, 2)
-        assert isinstance(mpm._mean_image, np.ndarray)
+        assert isinstance(mpm._mean_image, xr.core.dataarray.DataArray)
         assert isinstance(mpm._all_images, np.ndarray)
         assert mpm._mean_image.shape == self.simple_land.shape
         assert len(mpm._all_images.shape) == 3
@@ -161,7 +162,7 @@ class TestMorphologicalPlanform:
     def test_static_from_mask_negative_disk(self):
         mpm = plan.MorphologicalPlanform.from_mask(
             self.simple_land, -2)
-        assert isinstance(mpm.mean_image, np.ndarray)
+        assert isinstance(mpm.mean_image, xr.core.dataarray.DataArray)
         assert isinstance(mpm.all_images, np.ndarray)
         assert mpm.mean_image.shape == self.simple_land.shape
         assert len(mpm.all_images.shape) == 3


### PR DESCRIPTION
* change cube to pass coordinates to all arrays created. Update mask creation to get shape and coordinates from the underlying data, when available. This refactored the shape-setting mechanism, and is a private-api breaking change for masks (no change to public api).
* integrate `xarray` coordinates into underlying data for planform operations. When available computations on length or area of the planforms/masks will use the underlying data, pulled from the DataArray coordinates.
* integrate `xarray` coordinates into the section creating routine, so that the along-section coordinate has coordinate values rather than just idx coordinates.