### PR TITLE
Refactor section inputs

### DIFF
--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -149,6 +149,9 @@ class BaseCube(abc.ABC):
         self._dim1_coords = self._dim1_idx
         self._dim2_coords = self._dim2_idx
 
+        # DEVELOPER NOTE: can we remvoe the _dimX_idx altogether and just use
+        # the _dimX_coords arrays?
+
     def read(self, variables):
         """Read variable into memory.
 

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -276,9 +276,10 @@ class BaseCube(abc.ABC):
         When the API for instantiation of the different section types is
         settled, we should enable the ability to pass section kwargs to this
         method, and then instantiate the section internally. This avoids the
-        user having to specify ``dm.section.StrikeSection(y=5)`` in the
-        ``register_Section()`` call, and instead can do something like
-        ``rcm8cube.register_section('trial', trace='strike', y=5)``.
+        user having to specify ``dm.section.StrikeSection(distance=2000)`` in
+        the ``register_section()`` call, and instead can do something like
+        ``golf.register_section('trial', trace='strike',
+        distance=2000)``.
         """
 
         if not issubclass(type(SectionInstance), section.BaseSection):
@@ -617,10 +618,10 @@ class StratigraphyCube(BaseCube):
 
         Examples
         --------
-        Create a stratigraphy cube from the example ``rcm8cube``:
+        Create a stratigraphy cube from the example ``golf``:
 
-        >>> rcm8cube = dm.sample_data.rcm8()
-        >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
+        >>> golfcube = dm.sample_data.golf()
+        >>> stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
 
         Parameters
         ----------

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -528,16 +528,16 @@ def cartographic_colormap(H_SL=0.0, h=4.5, n=1.0):
     .. plot::
         :include-source:
 
-        rcm8cube = dm.sample_data.cube.rcm8()
+        golfcube = dm.sample_data.golf()
 
         cmap0, norm0 = dm.plot.cartographic_colormap(H_SL=0)
         cmap1, norm1 = dm.plot.cartographic_colormap(H_SL=0, h=5, n=0.5)
 
         fig, ax = plt.subplots(1, 2, figsize=(10, 4))
-        im0 = ax[0].imshow(rcm8cube['eta'][-1, ...], origin='lower',
+        im0 = ax[0].imshow(golfcube['eta'][-1, ...], origin='lower',
                        cmap=cmap0, norm=norm0)
         cb0 = dm.plot.append_colorbar(im0, ax[0])
-        im1 = ax[1].imshow(rcm8cube['eta'][-1, ...], origin='lower',
+        im1 = ax[1].imshow(golfcube['eta'][-1, ...], origin='lower',
                        cmap=cmap1, norm=norm1)
         cb1 = dm.plot.append_colorbar(im1, ax[1])
         plt.show()

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -57,7 +57,7 @@ def golf():
 
         golf = dm.sample_data.golf()
         nt = 5
-        ts = np.linspace(0, golf['eta'].shape[0]-1, num=nt, dtype=np.int)  # linearly interpolate ts
+        ts = np.linspace(0, golf['eta'].shape[0]-1, num=nt, dtype=np.int)
 
         fig, ax = plt.subplots(1, nt, figsize=(12, 2))
         for i, t in enumerate(ts):
@@ -92,14 +92,21 @@ def rcm8():
     this dataset is slated to be deprecated at some point, in favor of the
     :obj:`golf` dataset.
 
-    If you are learning to use DeltaMetrics or developing new codes or
-    documentation, please use the :obj:`golf` delta dataset.
+    .. important::
+        
+        If you are learning to use DeltaMetrics or developing new codes or
+        documentation, please use the :obj:`golf` delta dataset.
+
+    .. warning:: This cube may be removed in future releases.
 
     .. plot::
 
-        rcm8 = dm.sample_data.rcm8()
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            rcm8 = dm.sample_data.rcm8()
         nt = 5
-        ts = np.linspace(0, rcm8['eta'].shape[0]-1, num=nt, dtype=np.int)  # linearly interpolate ts
+        ts = np.linspace(0, rcm8['eta'].shape[0]-1, num=nt, dtype=np.int)
 
         fig, ax = plt.subplots(1, nt, figsize=(12, 2))
         for i, t in enumerate(ts):

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -460,7 +460,7 @@ class BaseSection(abc.ABC):
             >>> golfcube = dm.sample_data.golf()
             >>> golfcube.stratigraphy_from('eta')
             >>> golfcube.register_section(
-            ...     'demo', dm.section.StrikeSection(y=5))
+            ...     'demo', dm.section.StrikeSection(distance=250))
 
             >>> fig, ax = plt.subplots(4, 1, sharex=True, figsize=(6, 9))
             >>> golfcube.sections['demo'].show('depth', data='spacetime',
@@ -1208,7 +1208,7 @@ class CircularSection(BaseSection):
 
     Section drawn as a circular cut, located a along the arc a specified
     `radius` from specified `origin`.  Specify the location of the circular
-    section with :obj`radius` and :obj:`origin` keyword parameter options.
+    section with `radius` and `origin` keyword parameter options.
     The circular section trace is interpolated to the nearest integer model
     domain cells, following the mid-point circle algorithm
     (:obj:`~deltametrics.utils.circle_to_cells`).
@@ -1224,6 +1224,11 @@ class CircularSection(BaseSection):
         >>> golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)
         >>> golfcube.sections['circular'].show_trace('r--', ax=ax)
         >>> plt.show()
+
+    .. warning::
+
+        This section will not work for unequal `dim1` and `dim2` coordinate
+        spacing.
 
     Parameters
     ----------
@@ -1267,11 +1272,6 @@ class CircularSection(BaseSection):
         :obj:`register_section` method of a `Cube` is used to set up the
         section, or the `Cube` is passed as the first positional argument
         during instantiation.
-
-    .. warning::
-
-        This section will not work for unequal `dim1` and `dim2` coordinate
-        spacing.
 
     Examples
     --------
@@ -1414,7 +1414,7 @@ class RadialSection(BaseSection):
 
     Section drawn as a radial cut, located a along the line starting from
     `origin` and proceeding away in direction specified by azimuth. Specify
-    the location of the radial section with :obj`azimuth` and :obj:`origin`
+    the location of the radial section with `azimuth` and `origin`
     keyword parameter options. The radial section trace is interpolated to the
     nearest integer model domain cells, following the a line-walking algorithm
     (:obj:`~deltametrics.utils.line_to_cells`).

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -591,12 +591,12 @@ class PathSection(BaseSection):
     path : :obj:`ndarray`
         An `(N, 2)` `ndarray` specifying the `dim1-dim2` pairs of coordinates
         in dimensional values, defining the verticies of the path to extract
-        the section from. Mutually exclusive from :obj:`path_idx`.
+        the section from. Mutually exclusive with `path_idx`.
 
     path_idx : :obj:`ndarray`
         An `(N, 2)` `ndarray` specifying the `dim1-dim2` pairs of coordinates
         in dimension indices, defining the verticies of the path to extract
-        the section from. Mutually exclusive from :obj:`path`.
+        the section from. Mutually exclusive with `path`.
 
     **kwargs
         Keyword arguments are passed to `BaseSection.__init__()`. Supported
@@ -847,11 +847,11 @@ class StrikeSection(LineSection):
     distance : :obj:`float`, optional
         Distance *in `dim1` coordinates* from the `dim1` lower domain edge to
         place the section. The section location will be interpolated to the
-        nearest grid cell. Mutually exclusive with :obj:`distance_idx`.
+        nearest grid cell. Mutually exclusive with `distance_idx`.
 
     distance_idx : :obj:`int`, optional
         Distance *in cell indices* from the `dim1` lower domain edge to place
-        the section. Mutually exclusive with :obj:`distance`.
+        the section. Mutually exclusive with `distance`.
 
     length : :obj:`tuple` or :obj:`list` of `int` or `float`, optional
         A two-element tuple specifying the bounding points of the section in
@@ -1040,11 +1040,11 @@ class DipSection(LineSection):
     distance : :obj:`float`, optional
         Distance *in `dim2` coordinates* from the `dim2` lower domain edge to
         place the section. The section location will be interpolated to the
-        nearest grid cell. Mutually exclusive with :obj:`distance_idx`.
+        nearest grid cell. Mutually exclusive with `distance_idx`.
 
     distance_idx : :obj:`int`, optional
         Distance *in cell indices* from the `dim2` lower domain edge to place
-        the section. Mutually exclusive with :obj:`distance`.
+        the section. Mutually exclusive with `distance`.
 
     length : :obj:`tuple` or :obj:`list` of `int` or `float`, optional
         A two-element tuple specifying the bounding points of the section in
@@ -1248,12 +1248,12 @@ class CircularSection(BaseSection):
     radius_idx : :obj:`float`, `int`, optional
         The `radius` of the section in cell indices. This is the distance to
         locate the section from the :obj:`origin`. Mutually exclusive
-        with :obj:`radius`.
+        with `radius`.
 
     origin_idx : :obj:`tuple` of `int`, optional
         The `origin` of the circular section in dimensional coordinates,
         specified as a two-element tuple ``(dim1, dim2)``. This is the center
-        of the circle. Mutually exclusive with :obj:`origin`.
+        of the circle. Mutually exclusive with `origin`.
 
     **kwargs
         Keyword arguments are passed to `BaseSection.__init__()`. Supported
@@ -1467,7 +1467,7 @@ class RadialSection(BaseSection):
         The `origin` of the radial section in dimensional coordinates,
         specified as a two-element tuple ``(dim1, dim2)``. This is the
         starting point of the radial line. Mutually exclusive
-        with :obj:`origin`.
+        with `origin`.
 
     length : :obj:`float`, `int`, optional
         The length of the section (note this must be given in pixel length).

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -669,15 +669,14 @@ class StrikeSection(BaseSection):
     """Strike section object.
 
     Section oriented parallel to the `dim2` axis. Specify the location of the
-    strike section with :obj:`distance` and :obj:`length` *or* :obj:`distance_idx`
-    and :obj:`length` keyword parameters.
+    strike section with :obj:`distance` and :obj:`length` *or* 
+    :obj:`distance_idx` and :obj:`length` keyword parameters.
 
     .. plot::
 
         >>> golfcube = dm.sample_data.golf()
-        >>> golfcube.register_section('strike', dm.section.StrikeSection(distance=1500))
-
-        >>> # show the location and the "velocity" variable
+        >>> golfcube.register_section(
+        ...     'strike', dm.section.StrikeSection(distance=1500))
         >>> fig, ax = plt.subplots()
         >>> golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)
         >>> golfcube.sections['strike'].show_trace('r--', ax=ax)
@@ -704,10 +703,10 @@ class StrikeSection(BaseSection):
 
     length : :obj:`tuple` or :obj:`list` of `int` or `float`, optional
         A two-element tuple specifying the bounding points of the section in
-        the `dim2` axis. Values are treated as cell indices if :obj:`distance_idx` is
-        given and as `dim2` coordinates if :obj:`distance` is given. If no
-        value is supplied, the section is drawn across the entire `dim2`
-        axis (i.e., across the whole domain).
+        the `dim2` axis. Values are treated as cell indices
+        if :obj:`distance_idx` is given and as `dim2` coordinates
+        if :obj:`distance` is given. If no value is supplied, the section is
+        drawn across the entire `dim2` axis (i.e., across the whole domain).
 
     y : :obj:`int`, optional, deprecated
         The number of cells in from the `dim1` lower domain edge. If used, the
@@ -1017,22 +1016,23 @@ class CircularSection(BaseSection):
     """Circular section object.
 
     Section drawn as a circular cut, located a along the arc a specified
-    radius from specified origin.  Specify the location of the circular section
-    with :obj`radius` and :obj:`origin` keyword parameter options. The
-    circular section trace is interpolated to the nearest integer model domain
-    cells, following the mid-point circle algorithm
+    `radius` from specified `origin`.  Specify the location of the circular
+    section with :obj`radius` and :obj:`origin` keyword parameter options.
+    The circular section trace is interpolated to the nearest integer model
+    domain cells, following the mid-point circle algorithm
     (:obj:`~deltametrics.utils.circle_to_cells`).
 
-    .. important::
+    .. plot::
 
-        The `radius` and `origin` parameters must be specified as cell indices
-        (not actual x and y coordinate values). This is a needed patch.
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section(
+        ...     'circular', dm.section.CircularSection(radius=1200))
 
-    .. important::
-
-        The `origin` attempts to detect the land width from bed elevation
-        changes, but should use the value of ``L0`` recorded in the netcdf
-        file, or defined in the cube.
+        >>> # show the location and the "velocity" variable
+        >>> fig, ax = plt.subplots()
+        >>> golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)
+        >>> golfcube.sections['circular'].show_trace('r--', ax=ax)
+        >>> plt.show()
 
     Parameters
     ----------
@@ -1040,20 +1040,29 @@ class CircularSection(BaseSection):
         The `Cube` object to link for underlying data. This option should be
         ommitted if using the :obj:`register_section` method of a `Cube`.
 
-    radius : :obj:`float`, `int`, optional
-        The `radius` of the section. This is the distance to locate the
-        section from the :obj:`origin`. If no value is given, the `radius`
-        defaults to half of the minimum model domain edge length if it can be
-        determined, otherwise defaults to ``1``.
+    radius : :obj:`float`, optional
+        The `radius` of the section in dimensional coordinates. This is the
+        distance to locate the section from the :obj:`origin`. If no value is
+        given, the `radius` defaults to half of the minimum model domain edge
+        length.
 
-    origin : :obj:`tuple` or `list` of `int`, optional
-        The `origin` of the circular section. This is the center of the
-        circle. If no value is given, the origin defaults to the center of the
-        x-direction of the model domain, and offsets into the domain a
-        distance of ``y == L0``, if these values can be determined. I.e., the
-        origin defaults to be centered over the channel inlet. If no value is
-        given, and these values cannot be determined, the origin defaults to
-        ``(0, 0)``.
+    origin : :obj:`tuple` of `float`, optional
+        The `origin` of the circular section in dimensional coordinates,
+        specified as a two-element tuple ``(dim1, dim2)``. This is the center
+        of the circle. If no value is given, the origin defaults to the
+        center of the x-direction of the model domain, and offsets into the
+        domain a distance of ``y == L0``, if this values can be determined.
+        I.e., the origin defaults to be centered over the channel inlet.
+
+    radius_idx : :obj:`float`, `int`, optional
+        The `radius` of the section in cell indices. This is the distance to
+        locate the section from the :obj:`origin`. Mutually exclusive
+        with :obj:`radius`.
+
+    origin_idx : :obj:`tuple` of `int`, optional
+        The `origin` of the circular section in dimensional coordinates,
+        specified as a two-element tuple ``(dim1, dim2)``. This is the center
+        of the circle. Mutually exclusive with :obj:`origin`.
 
     **kwargs
         Keyword arguments are passed to `BaseSection.__init__()`. Supported
@@ -1068,24 +1077,49 @@ class CircularSection(BaseSection):
         section, or the `Cube` is passed as the first positional argument
         during instantiation.
 
+    .. warning::
+
+        This section will not work for unequal `dim1` and `dim2` coordinate
+        spacing.
+
     Examples
     --------
 
-    To create a `CircularSection` that is registered to a `DataCube` with
-    radius ``=30``, and using the default `origin` options:
+    Create a `CircularSection` that is registered to a `DataCube` with
+    radius ``=1200``, and using the default `origin` options:
 
     .. plot::
         :include-source:
 
         >>> golfcube = dm.sample_data.golf()
         >>> golfcube.register_section(
-        ...     'circular', dm.section.CircularSection(radius=30))
+        ...     'circular', dm.section.CircularSection(radius=1200))
 
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
         >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
         >>> golfcube.sections['circular'].show_trace('r--', ax=ax[0])
         >>> golfcube.sections['circular'].show('velocity', ax=ax[1])
+        >>> plt.show()
+
+    Create a `CircularSection` that is registered to a `StratigraphyCube` with
+    radius index ``=50``, and the origin against the domain edge (using the
+    `origin_idx` option):
+
+    .. plot::
+        :include-source:
+
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfstrat = dm.cube.StratigraphyCube.from_DataCube(golfcube)
+        >>> golfstrat.register_section(
+        ...     'circular', dm.section.CircularSection(radius_idx=50,
+        ...                                            origin_idx=(0, 100)))
+
+        >>> # show the location and the "velocity" variable
+        >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfstrat.sections['circular'].show_trace('r--', ax=ax[0])
+        >>> golfstrat.sections['circular'].show('velocity', ax=ax[1])
         >>> plt.show()
     """
 

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -572,12 +572,15 @@ class PathSection(BaseSection):
     the verticies of the path. All coordinates along the path will be
     included in the section.
 
-    .. important::
+    .. plot::
 
-        The vertex coordinates must be specified as cell indices along `dim1`
-        and `dim2`. That is to sat *not* actual `dim0` and `dim1` coordinate
-        values *and not* x-y cartesian indices (actually y-x indices).
-        Specifying coordinates is is a needed patch.
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section('path', dm.section.PathSection(
+        ...     path_idx=np.array([[3, 50], [17, 65], [10, 130]])))
+        >>> fig, ax = plt.subplots()
+        >>> golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)
+        >>> golfcube.sections['path'].show_trace('r--', ax=ax)
+        >>> plt.show()
 
     Parameters
     ----------
@@ -587,7 +590,13 @@ class PathSection(BaseSection):
 
     path : :obj:`ndarray`
         An `(N, 2)` `ndarray` specifying the `dim1-dim2` pairs of coordinates
-        that define the verticies of the path to extract the section from.
+        in dimensional values, defining the verticies of the path to extract
+        the section from. Mutually exclusive from :obj:`path_idx`.
+
+    path_idx : :obj:`ndarray`
+        An `(N, 2)` `ndarray` specifying the `dim1-dim2` pairs of coordinates
+        in dimension indices, defining the verticies of the path to extract
+        the section from. Mutually exclusive from :obj:`path`.
 
     **kwargs
         Keyword arguments are passed to `BaseSection.__init__()`. Supported
@@ -605,7 +614,7 @@ class PathSection(BaseSection):
     Examples
     --------
 
-    To create a `PathSection` that is registered to a `DataCube` at
+    Create a `PathSection` that is registered to a `DataCube` at
     specified coordinates:
 
     .. plot::
@@ -613,7 +622,24 @@ class PathSection(BaseSection):
 
         >>> golfcube = dm.sample_data.golf()
         >>> golfcube.register_section('path', dm.section.PathSection(
-        ...     path=np.array([[3, 50], [17, 65], [10, 130]])))
+        ...     path=np.array([[2000, 2000], [2000, 6000], [600, 7500]])))
+        >>>
+        >>> # show the location and the "velocity" variable
+        >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))
+        >>> golfcube.show_plan('eta', t=-1, ax=ax[0], ticks=True)
+        >>> golfcube.sections['path'].show_trace('r--', ax=ax[0])
+        >>> golfcube.sections['path'].show('velocity', ax=ax[1])
+        >>> plt.show()
+
+    Create a `PathSection` that is registered to a `DataCube` at
+    specified indices:
+
+    .. plot::
+        :include-source:
+
+        >>> golfcube = dm.sample_data.golf()
+        >>> golfcube.register_section('path', dm.section.PathSection(
+        ...     path_idx=np.array([[3, 50], [17, 65], [10, 130]])))
         >>>
         >>> # show the location and the "velocity" variable
         >>> fig, ax = plt.subplots(2, 1, figsize=(8, 4))

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -46,7 +46,7 @@ class NoStratigraphyError(AttributeError):
 
     .. doctest::
 
-        >>> raise utils.NoStratigraphyError(rcm8cube) #doctest: +SKIP
+        >>> raise utils.NoStratigraphyError(golfcube) #doctest: +SKIP
         deltametrics.utils.NoStratigraphyError: 'DataCube' object
         has no preservation or stratigraphy information.
 
@@ -54,7 +54,7 @@ class NoStratigraphyError(AttributeError):
 
     .. doctest::
 
-        >>> raise utils.NoStratigraphyError(rcm8cube, 'strat_attr') #doctest: +SKIP
+        >>> raise utils.NoStratigraphyError(golfcube, 'strat_attr') #doctest: +SKIP
         deltametrics.utils.NoStratigraphyError: 'DataCube' object
         has no attribute 'strat_attr'.
     """

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -334,7 +334,8 @@ def line_to_cells(*args):
     elif len(args) == 4:
         x0, y0, x1, y1 = args
     else:
-        raise TypeError
+        raise TypeError(
+            'Length of input must be 1, 2, or 4 but got: {0}'.format(args))
 
     # process the line to cells
     if np.abs(y1 - y0) < np.abs(x1 - x0):
@@ -342,6 +343,7 @@ def line_to_cells(*args):
         if x0 > x1:
             # if the line is trending down (III)
             x, y = _walk_line((x1, y1), (x0, y0))
+            x, y = np.flip(x), np.flip(y)  # flip order
         else:
             # if the line is trending up (I)
             x, y = _walk_line((x0, y0), (x1, y1))
@@ -350,6 +352,7 @@ def line_to_cells(*args):
         if y0 > y1:
             # if the line is trending down (IV)
             y, x = _walk_line((y1, x1), (y0, x0))
+            x, y = np.flip(x), np.flip(y)  # flip order
         else:
             # if the line is trending up (II)
             y, x = _walk_line((y0, x0), (y1, x1))

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -128,7 +128,7 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
 .. doctest::
 
-    >>> golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 which can then be accessed via the :obj:`~deltametrics.cube.Cube.sections` attribute of the Cube.
 

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -128,7 +128,7 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
 .. doctest::
 
-    >>> golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 which can then be accessed via the :obj:`~deltametrics.cube.Cube.sections` attribute of the Cube.
 

--- a/docs/source/guides/examples/computations/comparing_speeds_of_stratigraphy_access.rst
+++ b/docs/source/guides/examples/computations/comparing_speeds_of_stratigraphy_access.rst
@@ -10,9 +10,9 @@ Keeping data on disk is advantageous for large datasets, but slows down access c
     >>> import time
 
     >>> # set up the cubes
-    >>> rcm8cube = dm.sample_data.golf()
-    >>> sc8cube = dm.cube.StratigraphyCube.from_DataCube(rcm8cube, dz=0.05)
-    >>> fs, fe = dm.strat.compute_boxy_stratigraphy_volume(rcm8cube['eta'], rcm8cube['sandfrac'], dz=0.05)
+    >>> golfcube = dm.sample_data.golf()
+    >>> stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
+    >>> fs, fe = dm.strat.compute_boxy_stratigraphy_volume(golfcube['eta'], golfcube['sandfrac'], dz=0.05)
 
     >>> # time extraction from the frozen cube
     >>> start1 = time.time()
@@ -23,7 +23,7 @@ Keeping data on disk is advantageous for large datasets, but slows down access c
     >>> # time extraction from the underlying DataCube data on disk
     >>> start2 = time.time()
     >>> for _ in range(100):
-    ...     _val = sc8cube['sandfrac'].data[10:20, 31:35, -1:-30:-2]
+    ...     _val = stratcube['sandfrac'].data[10:20, 31:35, -1:-30:-2]
     >>> end2 = time.time()
 
     >>> print("Elapsed time for frozen cube: ", end1-start1, " seconds") #doctest: +SKIP

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -292,33 +292,16 @@ All Section types
 -----------------
 
 There are multiple section types available.
-The following are currently implemented.
-
-.. doctest::
-
-    >>> _strike = dm.section.StrikeSection(golfcube, distance_idx=18)
-    >>> _path = dm.section.PathSection(golfcube, path=np.column_stack((np.linspace(10, 90, num=4000, dtype=int),
-    ...                                                                np.linspace(50, 150, num=4000, dtype=int))))
-    >>> _circ = dm.section.CircularSection(golfcube, radius=40)
-    >>> _rad = dm.section.RadialSection(golfcube, azimuth=70)
-
-
 The `Section` classes all inherit from the same ``BaseSection`` class, which means they mostly have the same options available to them, and have a common API.
-Each has unique instantiation arguments, though, which must be properly specified.
+Each `Section` requires unique instantiation arguments, though, which must be properly specified.
+The below figure shows each section type available and the `velocity` spacetime data extracted along that section.
 
 .. doctest::
 
-    >>> fig = plt.figure(constrained_layout=True, figsize=(10, 8))
-    >>> spec = gs.GridSpec(ncols=2, nrows=3, figure=fig)
-    >>> ax0 = fig.add_subplot(spec[0, :])
-    >>> axs = [fig.add_subplot(spec[i, j]) for i, j in zip(np.repeat(np.arange(1, 3), 2), np.tile(np.arange(2), (3,)))]
-
-    >>> golfcube.show_plan('eta', t=-1, ax=ax0, ticks=True)
-    >>> for i, s in enumerate([_strike, _path, _circ, _rad]):
-    ...     ax0.plot(s.trace[:,0], s.trace[:,1], 'r--') #doctest: +SKIP
-    ...     s.show('velocity', ax=axs[i]) #doctest: +SKIP
-    ...     axs[i].set_title(s.section_type) #doctest: +SKIP
-    >>> plt.show() #doctest: +SKIP
+    >>> _strike = dm.section.StrikeSection(golfcube, distance=1200)
+    >>> _path = dm.section.PathSection(golfcube, path=np.array([[1400, 2000], [2000, 4000], [3000, 6000]]))
+    >>> _circ = dm.section.CircularSection(golfcube, radius=2000)
+    >>> _rad = dm.section.RadialSection(golfcube, azimuth=70)
 
 .. plot:: guides/userguide_section_type_demos.py
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -153,7 +153,7 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
 .. doctest::
 
-    >>> golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 which creates a section across a constant y-value ``==10``.
 The path of any `Section` in the ``x-y`` plane can always be accessed via the ``.trace`` attribute.
@@ -183,7 +183,7 @@ are sliced themselves, similarly to the cube.
 
 .. doctest::
 
-    >>> golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
     >>> golfcube.sections['demo']['velocity']
     <xarray.DataArray 'velocity' (time: 101, s: 200)>
     array([[0.2   , 0.2   , 0.2   , ..., 0.2   , 0.2   , 0.2   ],
@@ -220,7 +220,7 @@ You can also create a standalone section, which is not registered to the cube, b
 
 .. doctest::
 
-    >>> sass = dm.section.StrikeSection(golfcube, idx=10)
+    >>> sass = dm.section.StrikeSection(golfcube, distance_idx=10)
     >>> np.all(sass['velocity'] == golfcube.sections['demo']['velocity']) #doctest: +SKIP
     True
 
@@ -296,7 +296,7 @@ The following are currently implemented.
 
 .. doctest::
 
-    >>> _strike = dm.section.StrikeSection(golfcube, idx=18)
+    >>> _strike = dm.section.StrikeSection(golfcube, distance_idx=18)
     >>> _path = dm.section.PathSection(golfcube, path=np.column_stack((np.linspace(10, 90, num=4000, dtype=int),
     ...                                                                np.linspace(50, 150, num=4000, dtype=int))))
     >>> _circ = dm.section.CircularSection(golfcube, radius=40)
@@ -376,7 +376,7 @@ Let’s add a section at the same location as ``golfcube.sections['demo']``.
 
 .. doctest::
 
-    >>> stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
+    >>> stratcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
     >>> stratcube.sections
     {'demo': <deltametrics.section.StrikeSection object at 0x...>}
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -153,7 +153,7 @@ For a data cube, sections are most easily instantiated by the :obj:`~deltametric
 
 .. doctest::
 
-    >>> golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 which creates a section across a constant y-value ``==10``.
 The path of any `Section` in the ``x-y`` plane can always be accessed via the ``.trace`` attribute.
@@ -183,7 +183,7 @@ are sliced themselves, similarly to the cube.
 
 .. doctest::
 
-    >>> golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
     >>> golfcube.sections['demo']['velocity']
     <xarray.DataArray 'velocity' (time: 101, s: 200)>
     array([[0.2   , 0.2   , 0.2   , ..., 0.2   , 0.2   , 0.2   ],
@@ -220,7 +220,7 @@ You can also create a standalone section, which is not registered to the cube, b
 
 .. doctest::
 
-    >>> sass = dm.section.StrikeSection(golfcube, y=10)
+    >>> sass = dm.section.StrikeSection(golfcube, idx=10)
     >>> np.all(sass['velocity'] == golfcube.sections['demo']['velocity']) #doctest: +SKIP
     True
 
@@ -296,7 +296,7 @@ The following are currently implemented.
 
 .. doctest::
 
-    >>> _strike = dm.section.StrikeSection(golfcube, y=18)
+    >>> _strike = dm.section.StrikeSection(golfcube, idx=18)
     >>> _path = dm.section.PathSection(golfcube, path=np.column_stack((np.linspace(10, 90, num=4000, dtype=int),
     ...                                                                np.linspace(50, 150, num=4000, dtype=int))))
     >>> _circ = dm.section.CircularSection(golfcube, radius=40)
@@ -376,7 +376,7 @@ Let’s add a section at the same location as ``golfcube.sections['demo']``.
 
 .. doctest::
 
-    >>> stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
     >>> stratcube.sections
     {'demo': <deltametrics.section.StrikeSection object at 0x...>}
 

--- a/docs/source/guides/visualization.rst
+++ b/docs/source/guides/visualization.rst
@@ -14,23 +14,23 @@ Section display types
 
 .. doctest::
 
-    >>> rcm8cube = dm.sample_data.golf()
-    >>> rcm8cube.stratigraphy_from('eta')
-    >>> rcm8cube.register_section('demo', dm.section.StrikeSection(y=10))
+    >>> golfcube = dm.sample_data.golf()
+    >>> golfcube.stratigraphy_from('eta')
+    >>> golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
     >>> _v = 'velocity'
 
     >>> fig, ax = plt.subplots(3, 2, sharex=True, figsize=(8, 6))
-    >>> rcm8cube.sections['demo'].show(_v, style='lines', 
+    >>> golfcube.sections['demo'].show(_v, style='lines', 
     ...     data='spacetime', ax=ax[0,0]) #doctest: +SKIP
-    >>> rcm8cube.sections['demo'].show(_v, style='shaded',
+    >>> golfcube.sections['demo'].show(_v, style='shaded',
     ...     data='spacetime', ax=ax[0,1]) #doctest: +SKIP
-    >>> rcm8cube.sections['demo'].show(_v, style='lines',
+    >>> golfcube.sections['demo'].show(_v, style='lines',
     ...     data='preserved', ax=ax[1,0]) #doctest: +SKIP
-    >>> rcm8cube.sections['demo'].show(_v, style='shaded',
+    >>> golfcube.sections['demo'].show(_v, style='shaded',
     ...     data='preserved', ax=ax[1,1]) #doctest: +SKIP
-    >>> rcm8cube.sections['demo'].show(_v, style='lines',
+    >>> golfcube.sections['demo'].show(_v, style='lines',
     ...     data='stratigraphy', ax=ax[2,0]) #doctest: +SKIP
-    >>> rcm8cube.sections['demo'].show(_v, style='shaded',
+    >>> golfcube.sections['demo'].show(_v, style='shaded',
     ...     data='stratigraphy', ax=ax[2,1]) #doctest: +SKIP
     >>> plt.show(block=False) #doctest +SKIP
 

--- a/docs/source/pyplots/examples/preserved_velocities.py
+++ b/docs/source/pyplots/examples/preserved_velocities.py
@@ -29,7 +29,7 @@ _mstrat = np.full_like(_ys, np.nan, dtype=float)
 
 # loop through all of the sections defined in _ys
 for i, _y in enumerate(_ys):
-    _s = dm.section.StrikeSection(golfcube, y=_y)
+    _s = dm.section.StrikeSection(golfcube, idx=_y)
     _mall[i], _mstrat[i] = pick_velocities(_s)
 
 

--- a/docs/source/pyplots/examples/preserved_velocities.py
+++ b/docs/source/pyplots/examples/preserved_velocities.py
@@ -29,7 +29,7 @@ _mstrat = np.full_like(_ys, np.nan, dtype=float)
 
 # loop through all of the sections defined in _ys
 for i, _y in enumerate(_ys):
-    _s = dm.section.StrikeSection(golfcube, idx=_y)
+    _s = dm.section.StrikeSection(golfcube, distance_idx=_y)
     _mall[i], _mstrat[i] = pick_velocities(_s)
 
 

--- a/docs/source/pyplots/guides/10min_all_sections_strat.py
+++ b/docs/source/pyplots/guides/10min_all_sections_strat.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta', dz=0.05)
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(5, 1, sharex=True, figsize=(6, 8))
 ax = ax.flatten()

--- a/docs/source/pyplots/guides/10min_all_sections_strat.py
+++ b/docs/source/pyplots/guides/10min_all_sections_strat.py
@@ -3,7 +3,7 @@ import matplotlib.pyplot as plt
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta', dz=0.05)
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(5, 1, sharex=True, figsize=(6, 8))
 ax = ax.flatten()

--- a/docs/source/pyplots/guides/userguide_all_vars_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_all_vars_stratigraphy.py
@@ -1,7 +1,7 @@
 golfcube = dm.sample_data.golf()
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 9))
 ax = ax.flatten()

--- a/docs/source/pyplots/guides/userguide_all_vars_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_all_vars_stratigraphy.py
@@ -1,7 +1,7 @@
 golfcube = dm.sample_data.golf()
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
+stratcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 9))
 ax = ax.flatten()

--- a/docs/source/pyplots/guides/userguide_compare_slices.py
+++ b/docs/source/pyplots/guides/userguide_compare_slices.py
@@ -1,9 +1,9 @@
 import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(1, 2, figsize=(8, 2))
 golfcube.sections['demo'].show('velocity', ax=ax[0])

--- a/docs/source/pyplots/guides/userguide_compare_slices.py
+++ b/docs/source/pyplots/guides/userguide_compare_slices.py
@@ -1,9 +1,9 @@
 import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
+stratcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(1, 2, figsize=(8, 2))
 golfcube.sections['demo'].show('velocity', ax=ax[0])

--- a/docs/source/pyplots/guides/userguide_frozen_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_frozen_stratigraphy.py
@@ -2,10 +2,10 @@ import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fs = stratcube.export_frozen_variable('sandfrac')
 fe = stratcube.Z  # exported volume does not have coordinate information!

--- a/docs/source/pyplots/guides/userguide_frozen_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_frozen_stratigraphy.py
@@ -2,10 +2,10 @@ import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
+stratcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fs = stratcube.export_frozen_variable('sandfrac')
 fe = stratcube.Z  # exported volume does not have coordinate information!

--- a/docs/source/pyplots/guides/userguide_quick_stratigraphy_all_variables.py
+++ b/docs/source/pyplots/guides/userguide_quick_stratigraphy_all_variables.py
@@ -1,6 +1,6 @@
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 
 fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 12))

--- a/docs/source/pyplots/guides/userguide_quick_stratigraphy_all_variables.py
+++ b/docs/source/pyplots/guides/userguide_quick_stratigraphy_all_variables.py
@@ -1,6 +1,6 @@
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 
 fig, ax = plt.subplots(5, 1, sharex=True, sharey=True, figsize=(12, 12))

--- a/docs/source/pyplots/guides/userguide_quick_stratigraphy_sections.py
+++ b/docs/source/pyplots/guides/userguide_quick_stratigraphy_sections.py
@@ -1,6 +1,6 @@
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 
 fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 8))

--- a/docs/source/pyplots/guides/userguide_quick_stratigraphy_sections.py
+++ b/docs/source/pyplots/guides/userguide_quick_stratigraphy_sections.py
@@ -1,6 +1,6 @@
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 
 fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 8))

--- a/docs/source/pyplots/guides/userguide_section_type_demos.py
+++ b/docs/source/pyplots/guides/userguide_section_type_demos.py
@@ -2,7 +2,7 @@ import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 _strike = dm.section.StrikeSection(golfcube, y=18)
 __path = np.column_stack((np.linspace(10, 90, num=4000, dtype=int),

--- a/docs/source/pyplots/guides/userguide_section_type_demos.py
+++ b/docs/source/pyplots/guides/userguide_section_type_demos.py
@@ -2,11 +2,11 @@ import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 _strike = dm.section.StrikeSection(golfcube, y=18)
-__path = np.column_stack((np.linspace(50, 150, num=4000, dtype=int),
-                          np.linspace(10, 90, num=4000, dtype=int)))
+__path = np.column_stack((np.linspace(10, 90, num=4000, dtype=int),
+                          np.linspace(50, 150, num=4000, dtype=int)))
 _path = dm.section.PathSection(golfcube, path=__path)
 _circular = dm.section.CircularSection(golfcube, radius=40)
 _rad = dm.section.RadialSection(golfcube, azimuth=70)

--- a/docs/source/pyplots/guides/userguide_section_type_demos.py
+++ b/docs/source/pyplots/guides/userguide_section_type_demos.py
@@ -1,24 +1,31 @@
 import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
-golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
-_strike = dm.section.StrikeSection(golfcube, y=18)
-__path = np.column_stack((np.linspace(10, 90, num=4000, dtype=int),
-                          np.linspace(50, 150, num=4000, dtype=int)))
-_path = dm.section.PathSection(golfcube, path=__path)
-_circular = dm.section.CircularSection(golfcube, radius=40)
-_rad = dm.section.RadialSection(golfcube, azimuth=70)
+_strike = dm.section.StrikeSection(
+    golfcube, distance=1200)
+_dip = dm.section.DipSection(
+    golfcube, distance=3000)
+_path = dm.section.PathSection(
+    golfcube, path=np.array([[1400, 2000], [2000, 4000], [3000, 6000]]))
+_circ = dm.section.CircularSection(
+    golfcube, radius=2000)
+_rad = dm.section.RadialSection(
+    golfcube, azimuth=70)
 
-fig = plt.figure(constrained_layout=True, figsize=(10, 8))
-spec = gs.GridSpec(ncols=2, nrows=3, figure=fig, wspace=0.2, hspace=0.2)
+fig = plt.figure(constrained_layout=False, figsize=(10, 9))
+spec = gs.GridSpec(ncols=2, nrows=4, figure=fig, wspace=0.3, hspace=0.4,
+                   left=0.1, right=0.9, top=0.95, bottom=0.05,
+                   height_ratios=[1.5, 1, 1, 1])
 ax0 = fig.add_subplot(spec[0, :])
 axs = [fig.add_subplot(spec[i, j]) for i, j in zip(
-    np.repeat(np.arange(1, 3), 2), np.tile(np.arange(2), (3,)))]
+    np.repeat(np.arange(1, 4), 2), np.tile(np.arange(2), (4,)))]
 
+t10cmap = plt.cm.get_cmap('tab10')
 golfcube.show_plan('eta', t=-1, ax=ax0, ticks=True)
-for i, s in enumerate([_strike, _path, _circular, _rad]):
-    s.show_trace('--', ax=ax0)
+for i, s in enumerate([_strike, _dip, _path, _circ, _rad]):
+    s.show_trace('--', color=t10cmap(i), ax=ax0)
     s.show('velocity', ax=axs[i])
-    axs[i].set_title(s.section_type)
+    axs[i].set_title(s.section_type, color=t10cmap(i))
+
+fig.delaxes(axs[-1])

--- a/docs/source/pyplots/guides/userguide_stratigraphy_planform_slice.py
+++ b/docs/source/pyplots/guides/userguide_stratigraphy_planform_slice.py
@@ -1,7 +1,7 @@
 golfcube = dm.sample_data.golf()
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
+stratcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 elev_idx = (np.abs(stratcube.z - -2)).argmin()  # find nearest idx to -2 m
 

--- a/docs/source/pyplots/guides/userguide_stratigraphy_planform_slice.py
+++ b/docs/source/pyplots/guides/userguide_stratigraphy_planform_slice.py
@@ -1,7 +1,7 @@
 golfcube = dm.sample_data.golf()
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 elev_idx = (np.abs(stratcube.z - -2)).argmin()  # find nearest idx to -2 m
 

--- a/docs/source/pyplots/guides/userguide_strikesection_location.py
+++ b/docs/source/pyplots/guides/userguide_strikesection_location.py
@@ -1,5 +1,5 @@
 golfcube = dm.sample_data.golf()
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(figsize=(5, 3))
 golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)

--- a/docs/source/pyplots/guides/userguide_strikesection_location.py
+++ b/docs/source/pyplots/guides/userguide_strikesection_location.py
@@ -1,5 +1,5 @@
 golfcube = dm.sample_data.golf()
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(figsize=(5, 3))
 golfcube.show_plan('eta', t=-1, ax=ax, ticks=True)

--- a/docs/source/pyplots/guides/userguide_three_spacetime_sections.py
+++ b/docs/source/pyplots/guides/userguide_three_spacetime_sections.py
@@ -1,5 +1,5 @@
 golfcube = dm.sample_data.golf()
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 6))
 golfcube.show_section('demo', 'eta', ax=ax[0])

--- a/docs/source/pyplots/guides/userguide_three_spacetime_sections.py
+++ b/docs/source/pyplots/guides/userguide_three_spacetime_sections.py
@@ -1,5 +1,5 @@
 golfcube = dm.sample_data.golf()
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(3, 1, sharex=True, figsize=(12, 6))
 golfcube.show_section('demo', 'eta', ax=ax[0])

--- a/docs/source/pyplots/guides/userguide_three_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_three_stratigraphy.py
@@ -2,10 +2,10 @@ import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
+stratcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(3, 1, sharex=True, sharey=True, figsize=(12, 6))
 golfcube.sections['demo'].show('time', style='lines',

--- a/docs/source/pyplots/guides/userguide_three_stratigraphy.py
+++ b/docs/source/pyplots/guides/userguide_three_stratigraphy.py
@@ -2,10 +2,10 @@ import matplotlib.gridspec as gs
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 stratcube = dm.cube.StratigraphyCube.from_DataCube(golfcube, dz=0.05)
-stratcube.register_section('demo', dm.section.StrikeSection(y=10))
+stratcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(3, 1, sharex=True, sharey=True, figsize=(12, 6))
 golfcube.sections['demo'].show('time', style='lines',

--- a/docs/source/pyplots/guides/visualization_datacube_section_display_style.py
+++ b/docs/source/pyplots/guides/visualization_datacube_section_display_style.py
@@ -1,6 +1,6 @@
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
 fig, ax = plt.subplots(3, 2, sharex=True, figsize=(8, 6))
 _v = 'velocity'

--- a/docs/source/pyplots/guides/visualization_datacube_section_display_style.py
+++ b/docs/source/pyplots/guides/visualization_datacube_section_display_style.py
@@ -1,6 +1,6 @@
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(3, 2, sharex=True, figsize=(8, 6))
 _v = 'velocity'

--- a/docs/source/pyplots/mask/channelmask.py
+++ b/docs/source/pyplots/mask/channelmask.py
@@ -3,6 +3,6 @@ import deltametrics as dm
 from deltametrics.mask import ChannelMask
 
 golfcube = dm.sample_data.golf()
-channel_mask = ChannelMask(rcm8cube['velocity'].data[-1, :, :],
-                           rcm8cube['eta'].data[-1, :, :])
+channel_mask = ChannelMask(golfcube['velocity'].data[-1, :, :],
+                           golfcube['eta'].data[-1, :, :])
 channel_mask.show()

--- a/docs/source/pyplots/section/section_demo_quick_strat.py
+++ b/docs/source/pyplots/section/section_demo_quick_strat.py
@@ -4,7 +4,7 @@ import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=5))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=5))
 
 fig, ax = plt.subplots(4, 1, sharex=True, figsize=(8, 6))
 golfcube.sections['demo'].show('depth', data='spacetime',

--- a/docs/source/pyplots/section/section_demo_quick_strat.py
+++ b/docs/source/pyplots/section/section_demo_quick_strat.py
@@ -4,7 +4,7 @@ import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=5))
+golfcube.register_section('demo', dm.section.StrikeSection(distance=250))
 
 fig, ax = plt.subplots(4, 1, sharex=True, figsize=(8, 6))
 golfcube.sections['demo'].show('depth', data='spacetime',

--- a/docs/source/pyplots/section/section_demo_quick_strat.py
+++ b/docs/source/pyplots/section/section_demo_quick_strat.py
@@ -4,7 +4,7 @@ import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=5))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=5))
 
 fig, ax = plt.subplots(4, 1, sharex=True, figsize=(8, 6))
 golfcube.sections['demo'].show('depth', data='spacetime',

--- a/docs/source/pyplots/section/section_demo_spacetime.py
+++ b/docs/source/pyplots/section/section_demo_spacetime.py
@@ -6,5 +6,5 @@ golfcube = dm.sample_data.golf()
 
 
 fig, ax = plt.subplots(figsize=(8, 2))
-golfcube.register_section('demo', dm.section.StrikeSection(y=5))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=5))
 golfcube.sections['demo'].show('velocity')

--- a/docs/source/pyplots/section/section_demo_spacetime.py
+++ b/docs/source/pyplots/section/section_demo_spacetime.py
@@ -6,5 +6,5 @@ golfcube = dm.sample_data.golf()
 
 
 fig, ax = plt.subplots(figsize=(8, 2))
-golfcube.register_section('demo', dm.section.StrikeSection(idx=5))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=5))
 golfcube.sections['demo'].show('velocity')

--- a/docs/source/pyplots/section/section_lexicon.py
+++ b/docs/source/pyplots/section/section_lexicon.py
@@ -4,7 +4,7 @@ import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
+golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
 
 fig, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 4))
 

--- a/docs/source/pyplots/section/section_lexicon.py
+++ b/docs/source/pyplots/section/section_lexicon.py
@@ -4,17 +4,17 @@ import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')
-golfcube.register_section('demo', dm.section.StrikeSection(y=10))
+golfcube.register_section('demo', dm.section.StrikeSection(idx=10))
 
-fig, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 3.5))
+fig, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 4))
 
-ax[0].imshow(golfcube.sections['demo']['velocity'],
-             origin='lower', cmap=golfcube.varset['velocity'].cmap)
+golfcube.sections['demo'].show('velocity', ax=ax[0])
 ax[0].set_ylabel('$t$ coordinate')
 
-ax[1].imshow(golfcube.sections['demo']['velocity'].strat.as_preserved(),
-             origin='lower', cmap=golfcube.varset['velocity'].cmap)
+golfcube.sections['demo'].show('velocity', data='preserved', ax=ax[1])
 ax[1].set_ylabel('$t$ coordinate')
 
 ax[1].set_xlabel('$s$ coordinate')
+
+plt.tight_layout()
 plt.show()

--- a/docs/source/reference/plan/index.rst
+++ b/docs/source/reference/plan/index.rst
@@ -18,18 +18,18 @@ Planform types
     :toctree: ../../_autosummary
 
     OpeningAnglePlanform
-		MorphologicalPlanform
+    MorphologicalPlanform
 
 Functions
 =========
 
 .. autosummary::
-	:toctree: ../../_autosummary
+    :toctree: ../../_autosummary
 
-	compute_shoreline_roughness
-	compute_shoreline_length
-  compute_shoreline_distance
-  compute_channel_width
-	compute_channel_depth
-	shaw_opening_angle_method
-	morphological_closing_method
+    compute_shoreline_roughness
+    compute_shoreline_length
+    compute_shoreline_distance
+    compute_channel_width
+    compute_channel_depth
+    shaw_opening_angle_method
+    morphological_closing_method

--- a/docs/source/reference/sample_data/index.rst
+++ b/docs/source/reference/sample_data/index.rst
@@ -18,7 +18,7 @@ The sample data cubes can be accessed as, for example:
 .. doctest::
 
     >>> import deltametrics as dm
-    >>> rcm8cube = dm.sample_data.rcm8()
+    >>> golfcube = dm.sample_data.golf()
 
 .. note::
 
@@ -46,7 +46,7 @@ Paths to data files
 	The file path to each sample data cube can be accessed by a call to
 	`sample_data._get_xxxxxx_path()`  for the corresponding data set.
 
-.. doctest::
+.. code::
 
-	>>> dm.sample_data._get_rcm8_path()
-	'.../pyDeltaRCM_Output_8.nc'
+	>>> dm.sample_data._get_golf_path()
+	'<cache-path>/deltametrics/golf.zip.unzip/pyDeltaRCM_output.nc'

--- a/docs/source/reference/section/index.rst
+++ b/docs/source/reference/section/index.rst
@@ -10,10 +10,6 @@ All classes inherit from :obj:`BaseSection`, and redefine methods and attributes
 
 The classes are defined in ``deltametrics.section``. 
 
-
-.. include:: lexicon.rst
-
-
 Section types
 ==============
 
@@ -28,3 +24,9 @@ Section types
     CircularSection
     RadialSection
     BaseSection
+
+
+Information about Sections
+==========================
+
+.. include:: lexicon.rst

--- a/docs/source/reference/section/lexicon.rst
+++ b/docs/source/reference/section/lexicon.rst
@@ -12,7 +12,7 @@ The data that make up the section can view the section as a `spacetime` section 
 .. doctest::
 
     >>> rcm8cube = dm.sample_data.golf()
-    >>> strike = dm.section.StrikeSection(rcm8cube, idx=10)
+    >>> strike = dm.section.StrikeSection(rcm8cube, distance_idx=10)
     >>> strike['velocity']
     <xarray.DataArray 'velocity' (time: 101, s: 200)>
     array([[0.2   , 0.2   , 0.2   , ..., 0.2   , 0.2   , 0.2   ],

--- a/docs/source/reference/section/lexicon.rst
+++ b/docs/source/reference/section/lexicon.rst
@@ -3,7 +3,7 @@
 
 The `Section` module defines some terms that are used throughout the code and rest of the documentation. 
 
-Most importantly, a Section is defined by a set of coordinates in the x-y plane of a `Cube`.
+Most importantly, a Section is defined by a set of coordinates in the `dim1`-`dim2` plane of a `Cube`.
 
 Therefore, we transform variable definitions when extracting the `Section`, and the coordinate system of the section is defined by the along-section direction :math:`s` and a vertical section coordinate, which is :math:`z` when viewing stratigraphy, and :math:`t` when viewing a spacetime section.
 
@@ -12,7 +12,7 @@ The data that make up the section can view the section as a `spacetime` section 
 .. doctest::
 
     >>> rcm8cube = dm.sample_data.golf()
-    >>> strike = dm.section.StrikeSection(rcm8cube, y=10)
+    >>> strike = dm.section.StrikeSection(rcm8cube, idx=10)
     >>> strike['velocity']
     <xarray.DataArray 'velocity' (time: 101, s: 200)>
     array([[0.2   , 0.2   , 0.2   , ..., 0.2   , 0.2   , 0.2   ],
@@ -64,12 +64,13 @@ We can display the arrays using `matplotlib` to examine the spatiotemporal chang
 .. code::
 
     >>> fig, ax = plt.subplots(2, 1, sharex=True, figsize=(6, 3.5))
-    >>> ax[0].imshow(rcm8cube.sections['demo']['velocity'],
-    ...              origin='lower', cmap=rcm8cube.varset['velocity'].cmap)
+    >>> golfcube.sections['demo'].show('velocity', ax=ax[0])
     >>> ax[0].set_ylabel('$t$ coordinate')
-    >>> ax[1].imshow(rcm8cube.sections['demo']['velocity'].as_preserved(),
-    ...              origin='lower', cmap=rcm8cube.varset['velocity'].cmap)
+
+    >>> golfcube.sections['demo'].show('velocity', data='preserved', ax=ax[1])
     >>> ax[1].set_ylabel('$t$ coordinate')
+    
+    >>> ax[1].set_xlabel('$s$ coordinate')
 
 .. plot:: section/section_lexicon.py
 

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -91,7 +91,8 @@ class TestDataCubeNoStratigraphy:
     def test_register_section(self):
         golf = cube.DataCube(golf_path)
         golf.stratigraphy_from('eta', dz=0.1)
-        golf.register_section('testsection', section.StrikeSection(y=10))
+        golf.register_section(
+            'testsection', section.StrikeSection(distance_idx=10))
         assert golf.sections is golf.section_set
         assert len(golf.sections.keys()) == 1
         assert 'testsection' in golf.sections.keys()
@@ -99,7 +100,8 @@ class TestDataCubeNoStratigraphy:
     def test_sections_slice_op(self):
         golf = cube.DataCube(golf_path)
         golf.stratigraphy_from('eta', dz=0.1)
-        golf.register_section('testsection', section.StrikeSection(y=10))
+        golf.register_section(
+            'testsection', section.StrikeSection(distance_idx=10))
         assert 'testsection' in golf.sections.keys()
         slc = golf.sections['testsection']
         assert issubclass(type(slc), section.BaseSection)
@@ -110,7 +112,8 @@ class TestDataCubeNoStratigraphy:
 
     def test_nostratigraphy_default_attribute_derived_variable(self):
         golf = cube.DataCube(golf_path)
-        golf.register_section('testsection', section.StrikeSection(y=10))
+        golf.register_section(
+            'testsection', section.StrikeSection(distance_idx=10))
         assert golf._knows_stratigraphy is False
         with pytest.raises(utils.NoStratigraphyError):
             golf.sections['testsection']['velocity'].strat.as_stratigraphy()
@@ -176,7 +179,7 @@ class TestDataCubeNoStratigraphy:
         assert self.fixeddatacube.shape == self.fdc_shape
 
     def test_section_no_stratigraphy(self):
-        sc = section.StrikeSection(self.fixeddatacube, y=10)
+        sc = section.StrikeSection(self.fixeddatacube, distance_idx=10)
         _ = sc['velocity'][:, 1]
         assert not hasattr(sc, 'strat_attr')
         with pytest.raises(utils.NoStratigraphyError):
@@ -251,7 +254,7 @@ class TestDataCubeWithStratigraphy:
 
     def test_section_with_stratigraphy(self):
         assert hasattr(self.fixeddatacube, 'strat_attr')
-        sc = section.StrikeSection(self.fixeddatacube, y=10)
+        sc = section.StrikeSection(self.fixeddatacube, distance_idx=10)
         assert sc.strat_attr is self.fixeddatacube.strat_attr
         _take = sc['velocity'][:, 1]
         assert _take.shape == (self.fixeddatacube.shape[0],)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -403,7 +403,7 @@ class TestComputeChannelWidth:
         golf['velocity'][-1, :, :],
         elevation_threshold=0,
         flow_threshold=0.3)
-    sec = section.CircularSection(golf, radius=40)
+    sec = section.CircularSection(golf, radius_idx=40)
 
     def test_widths_simple(self):
         """Get mean and std from simple."""
@@ -480,7 +480,7 @@ class TestComputeChannelDepth:
         golf['velocity'][-1, :, :],
         elevation_threshold=0,
         flow_threshold=0.3)
-    sec = section.CircularSection(golf, radius=40)
+    sec = section.CircularSection(golf, radius_idx=40)
 
     def test_depths_simple_thalweg(self):
         """Get mean and std from simple."""

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -451,6 +451,9 @@ class TestRadialSection:
         assert sars4.trace.shape[0] == 41  # 2000 // 50 = L // dx == 40
         assert sars4.azimuth == 90
         assert sars4._origin_idx == (4, rcm8cube.W // 2)  # 5000 is center domain
+        with pytest.raises(ValueError, match=r'Cannot specify .*'):
+            _ = section.RadialSection(  # both arguments
+                rcm8cube, origin=(200, 5000), origin_idx=(2, 90))
 
     def test_standalone_instantiation_withmeta(self):
         golfcube = cube.DataCube(

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -94,6 +94,12 @@ class TestStrikeSection:
         assert rcm8cube.sections['lengthtest'].length == (2000, 5000)
         assert rcm8cube.sections['lengthtest'].distance == 2000
 
+    def test_StrikeSection_register_section_either_distance_idx(self):
+        rcm8cube = cube.DataCube(golf_path)
+        with pytest.raises(ValueError, match=r'Must specify `distance` or .*'):
+            rcm8cube.register_section(
+                'test', section.StrikeSection())
+
     def test_StrikeSection_register_section_notboth_distance_idx(self):
         rcm8cube = cube.DataCube(golf_path)
         with pytest.raises(ValueError, match=r'Cannot specify both `distance` .*'):  # noqa: E501

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -21,10 +21,10 @@ class TestStrikeSection:
     """Test the basic of the StrikeSection."""
 
     def test_StrikeSection_without_cube(self):
-        ss = section.StrikeSection(idx=5)
+        ss = section.StrikeSection(distance_idx=5)
         assert ss.name is None
         assert ss.idx is None
-        assert ss._input_idx == 5
+        assert ss._input_distance_idx == 5
         assert ss.shape is None
         assert ss.cube is None
         assert ss.s is None
@@ -38,13 +38,13 @@ class TestStrikeSection:
     def test_StrikeSection_bad_cube(self):
         badcube = ['some', 'list']
         with pytest.raises(TypeError, match=r'Expected type is *.'):
-            _ = section.StrikeSection(badcube, idx=12)
+            _ = section.StrikeSection(badcube, distance_idx=12)
         with pytest.raises(TypeError, match=r'Expected type is *.'):
             _ = section.StrikeSection(badcube, distance=1000)
 
     def test_StrikeSection_standalone_instantiation(self):
         rcm8cube = cube.DataCube(golf_path)
-        sass = section.StrikeSection(rcm8cube, idx=12)
+        sass = section.StrikeSection(rcm8cube, distance_idx=12)
         assert sass.name == 'strike'
         assert sass.y == 12
         assert sass.cube == rcm8cube
@@ -53,10 +53,10 @@ class TestStrikeSection:
 
     def test_StrikeSection_register_section_idx(self):
         rcm8cube = cube.DataCube(golf_path)
-        rcm8cube.register_section('test', section.StrikeSection(idx=5))
+        rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
         assert rcm8cube.sections['test'].name == 'test'
         assert rcm8cube.sections['test']._input_distance is None
-        assert rcm8cube.sections['test']._input_idx == 5
+        assert rcm8cube.sections['test']._input_distance_idx == 5
         assert rcm8cube.sections['test']._input_length is None
         assert rcm8cube.sections['test'].idx == 5
         assert rcm8cube.sections['test'].length == (0, rcm8cube.shape[2])
@@ -66,9 +66,9 @@ class TestStrikeSection:
         # test that the name warning is raised
         with pytest.warns(UserWarning, match=r'`name` argument supplied .*'):
             rcm8cube.register_section('testname', section.StrikeSection(
-                idx=5, name='TESTING'))
+                distance_idx=5, name='TESTING'))
             assert rcm8cube.sections['testname'].name == 'TESTING'
-        _sect = rcm8cube.register_section('test', section.StrikeSection(idx=5),
+        _sect = rcm8cube.register_section('test', section.StrikeSection(distance_idx=5),
                                           return_section=True)
         assert isinstance(_sect, section.StrikeSection)
 
@@ -77,7 +77,7 @@ class TestStrikeSection:
         rcm8cube.register_section('test', section.StrikeSection(distance=2000))
         assert rcm8cube.sections['test'].name == 'test'
         assert rcm8cube.sections['test']._input_distance == 2000
-        assert rcm8cube.sections['test']._input_idx is None
+        assert rcm8cube.sections['test']._input_distance_idx is None
         assert rcm8cube.sections['test']._input_length is None
         assert rcm8cube.sections['test'].idx > 0
         assert rcm8cube.sections['test'].length == (0, rcm8cube.dim2_coords[-1])
@@ -88,23 +88,23 @@ class TestStrikeSection:
             distance=2000, length=(2000, 5000)))
         assert rcm8cube.sections['lengthtest'].name == 'lengthtest'
         assert rcm8cube.sections['lengthtest']._input_distance == 2000
-        assert rcm8cube.sections['lengthtest']._input_idx is None
+        assert rcm8cube.sections['lengthtest']._input_distance_idx is None
         assert rcm8cube.sections['lengthtest']._input_length == (2000, 5000)
         assert rcm8cube.sections['lengthtest'].idx > 0
         assert rcm8cube.sections['lengthtest'].length == (2000, 5000)
         assert rcm8cube.sections['lengthtest'].distance == 2000
 
-    def test_StrikeSection_register_section_either_distance_idx(self):
+    def test_StrikeSection_register_section_either_distance_distance_idx(self):
         rcm8cube = cube.DataCube(golf_path)
         with pytest.raises(ValueError, match=r'Must specify `distance` or .*'):
             rcm8cube.register_section(
                 'test', section.StrikeSection())
 
-    def test_StrikeSection_register_section_notboth_distance_idx(self):
+    def test_StrikeSection_register_section_notboth_distance_distance_idx(self):
         rcm8cube = cube.DataCube(golf_path)
         with pytest.raises(ValueError, match=r'Cannot specify both `distance` .*'):  # noqa: E501
             rcm8cube.register_section(
-                'test', section.StrikeSection(distance=2000, idx=2))
+                'test', section.StrikeSection(distance=2000, distance_idx=2))
 
     def test_StrikeSection_register_section_deprecated(self):
         rcm8cube = cube.DataCube(golf_path)
@@ -113,7 +113,7 @@ class TestStrikeSection:
         # the section should still work though, so check on the attrs
         assert rcm8cube.sections['warn'].name == 'warn'
         assert rcm8cube.sections['warn']._input_distance is None
-        assert rcm8cube.sections['warn']._input_idx == 5
+        assert rcm8cube.sections['warn']._input_distance_idx == 5
         assert rcm8cube.sections['warn']._input_length is None
         assert rcm8cube.sections['warn'].idx == 5
         assert rcm8cube.sections['warn'].length == (0, rcm8cube.shape[2])
@@ -123,14 +123,14 @@ class TestStrikeSection:
         # test for the error with spec deprecated and new
         with pytest.raises(ValueError, match=r'Cannot specify `distance`, .*'):  # noqa: E501
             rcm8cube.register_section(
-                'fail', section.StrikeSection(y=2, distance=2000, idx=2))
+                'fail', section.StrikeSection(y=2, distance=2000, distance_idx=2))
 
     def test_StrikeSection_register_section_x_limits(self):
         rcm8cube = cube.DataCube(golf_path)
         rcm8cube.register_section(
-            'tuple', section.StrikeSection(idx=5, length=(10, 110)))
+            'tuple', section.StrikeSection(distance_idx=5, length=(10, 110)))
         rcm8cube.register_section(
-            'list', section.StrikeSection(idx=5, length=[20, 110]))
+            'list', section.StrikeSection(distance_idx=5, length=[20, 110]))
         assert len(rcm8cube.sections) == 2
         assert rcm8cube.sections['tuple']._dim2_idx.shape[0] == 100
         assert rcm8cube.sections['list']._dim2_idx.shape[0] == 90
@@ -211,7 +211,7 @@ class TestPathSection:
                               np.linspace(50, 150, num=4000, dtype=int)))
         saps1 = section.PathSection(rcm8cube, path=xy)
         assert saps1.path.shape != xy.shape
-        assert np.all(saps1._idx_trace == np.unique(xy, axis=0))
+        assert np.all(saps1.trace_idx == np.unique(xy, axis=0))
 
         # test a second case with small line to ensure non-unique removed
         saps2 = section.PathSection(rcm8cube, path=np.array([[50, 25],
@@ -225,7 +225,7 @@ class TestCircularSection:
     """Test the basic of the CircularSection."""
 
     def test_without_cube(self):
-        cs = section.CircularSection(radius=30)
+        cs = section.CircularSection(radius_idx=30)
         assert cs.name is None
         assert cs.shape is None
         assert cs.cube is None
@@ -234,66 +234,105 @@ class TestCircularSection:
         assert cs._dim1_idx is None
         assert cs._dim2_idx is None
         assert cs.variables is None
+        assert cs.radius is None
+        assert cs.origin is None
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             cs['velocity']
 
     def test_bad_cube(self):
         badcube = ['some', 'list']
         with pytest.raises(TypeError, match=r'Expected type is *.'):
-            _ = section.CircularSection(badcube, radius=30)
+            _ = section.CircularSection(badcube, radius_idx=30)
 
     def test_standalone_instantiation(self):
-        rcm8cube = cube.DataCube(
-            golf_path)
-        sacs = section.CircularSection(rcm8cube, radius=30)
-        assert sacs.name == 'circular'
-        assert sacs.cube == rcm8cube
-        assert sacs.trace.shape[0] == 85
-        assert len(sacs.variables) > 0
-        sacs2 = section.CircularSection(rcm8cube, radius=30, origin=(10, 0))
-        assert sacs2.name == 'circular'
-        assert sacs2.cube == rcm8cube
-        assert sacs2.trace.shape[0] == 53
-        assert len(sacs2.variables) > 0
-        assert sacs2.origin == (10, 0)
-
-    def test_standalone_instantiation_withmeta(self):
         golfcube = cube.DataCube(
             golf_path)
-        sacs = section.CircularSection(golfcube, radius=30)
+        sacs = section.CircularSection(
+            golfcube, radius_idx=30)
         assert sacs.name == 'circular'
         assert sacs.cube == golfcube
         assert sacs.trace.shape[0] == 85
+        assert sacs._input_radius_idx == 30
         assert len(sacs.variables) > 0
-        assert sacs.origin[1] == golfcube.meta['L0']
-        sacs2 = section.CircularSection(golfcube, radius=30, origin=(10, 0))
+        assert sacs._origin_idx[0] == golfcube.meta['L0']
+        assert sacs.radius == 1500
+
+        sacs2 = section.CircularSection(
+            golfcube, radius_idx=30, origin_idx=(0, 10))
         assert sacs2.name == 'circular'
         assert sacs2.cube == golfcube
         assert sacs2.trace.shape[0] == 53
         assert len(sacs2.variables) > 0
-        assert sacs2.origin == (10, 0)
+        assert sacs2._origin_idx == (0, 10)
 
-    @pytest.mark.xfail(AttributeError, reason='Not called if no cube.')
-    def no_radius_if_no_cube(self):
-        sacs3 = section.CircularSection()
-        assert sacs3.radius == 1
+        sacs3 = section.CircularSection(
+            golfcube, radius=2500)
+        assert sacs3.name == 'circular'
+        assert sacs3.cube == golfcube
+        assert sacs3.trace.shape[0] == 143
+        assert len(sacs3.variables) > 0
+        assert sacs3._origin_idx == (int(golfcube.meta['L0']),
+                                     golfcube.shape[2]//2)
+        assert sacs3._radius_idx == 50
+        assert sacs3.radius == 2500
+        assert sacs3.radius == sacs3._radius
+
+        sacs4 = section.CircularSection(
+            golfcube, origin=(1200, 1500))
+        assert sacs4.name == 'circular'
+        assert sacs4.cube == golfcube
+        assert sacs4.trace.shape[0] == 102
+        assert len(sacs4.variables) > 0
+        assert sacs4._origin_idx == (1200 // 50,  # 50 is dx
+                                     1500 // 50)
+        assert sacs4._radius_idx == 50
+        assert sacs4.radius == 2500
+        assert sacs4.radius == sacs4._radius
+
+    def test_standalone_instantiation_legacy_nometa(self):
+        with pytest.warns(UserWarning, match=r'Coordinates for "time".*'):
+            rcm8cube = cube.DataCube(rcm8_path)
+        # test that it guesses the origin
+        sacs = section.CircularSection(
+            rcm8cube, radius_idx=30)
+        assert sacs.name == 'circular'
+        assert sacs.cube == rcm8cube
+        assert sacs.trace.shape[0] == 85
+        assert len(sacs.variables) > 0
+        # test that it uses the origin
+        sacs2 = section.CircularSection(
+            rcm8cube, radius_idx=30, origin_idx=(0, 10))
+        assert sacs2.name == 'circular'
+        assert sacs2.cube == rcm8cube
+        assert sacs2.trace.shape[0] == 53
+        assert len(sacs2.variables) > 0
+        assert sacs2._origin_idx == (0, 10)
+
+    def test_standalone_instantiation_both_coord_idx_inputs(self):
+        golfcube = cube.DataCube(golf_path)
+        with pytest.raises(ValueError, match=r'.*`radius` and `radius_idx`'):
+            _ = section.CircularSection(
+                golfcube, radius=2500, radius_idx=30)
+        with pytest.raises(ValueError, match=r'.*`origin` and `origin_idx`'):
+            _ = section.CircularSection(
+                golfcube, origin=(2500, 1500), origin_idx=(3, 100))
 
     def test_register_section(self):
         rcm8cube = cube.DataCube(
             golf_path)
         rcm8cube.stratigraphy_from('eta')
         rcm8cube.register_section(
-            'test', section.CircularSection(radius=30))
+            'test', section.CircularSection(radius_idx=30))
         assert len(rcm8cube.sections['test'].variables) > 0
         # test that the name warning is raised
         assert isinstance(rcm8cube.sections['test'], section.CircularSection)
         with pytest.warns(UserWarning):
             rcm8cube.register_section(
-                'test2', section.CircularSection(radius=31, name='different'))
-            assert rcm8cube.sections['test2'].name == 'different'
+                'test2', section.CircularSection(radius_idx=31, name='diff'))
+            assert rcm8cube.sections['test2'].name == 'diff'
         rcm8cube.register_section(
             'test3', section.CircularSection())
-        assert rcm8cube.sections['test3'].radius == rcm8cube.shape[1] // 2
+        assert rcm8cube.sections['test3']._radius_idx == rcm8cube.shape[1] // 2
         _section = rcm8cube.register_section(
             'test3', section.CircularSection(), return_section=True)
         assert isinstance(_section, section.CircularSection)
@@ -302,14 +341,14 @@ class TestCircularSection:
         # we try this for a bunch of different radii
         rcm8cube = cube.DataCube(
             golf_path)
-        sacs1 = section.CircularSection(rcm8cube, radius=40)
-        assert len(sacs1._idx_trace) == len(np.unique(sacs1._idx_trace, axis=0))
-        sacs2 = section.CircularSection(rcm8cube, radius=23)
-        assert len(sacs2._idx_trace) == len(np.unique(sacs2._idx_trace, axis=0))
-        sacs3 = section.CircularSection(rcm8cube, radius=17)
-        assert len(sacs3._idx_trace) == len(np.unique(sacs3._idx_trace, axis=0))
-        sacs4 = section.CircularSection(rcm8cube, radius=33)
-        assert len(sacs4._idx_trace) == len(np.unique(sacs4._idx_trace, axis=0))
+        sacs1 = section.CircularSection(rcm8cube, radius_idx=40)
+        assert len(sacs1.trace_idx) == len(np.unique(sacs1.trace_idx, axis=0))
+        sacs2 = section.CircularSection(rcm8cube, radius_idx=23)
+        assert len(sacs2.trace_idx) == len(np.unique(sacs2.trace_idx, axis=0))
+        sacs3 = section.CircularSection(rcm8cube, radius_idx=17)
+        assert len(sacs3.trace_idx) == len(np.unique(sacs3.trace_idx, axis=0))
+        sacs4 = section.CircularSection(rcm8cube, radius_idx=33)
+        assert len(sacs4.trace_idx) == len(np.unique(sacs4.trace_idx, axis=0))
 
 
 class TestRadialSection:
@@ -493,10 +532,14 @@ class TestCubesWithManySections:
                       self.sc8cube.dataio['velocity'])
 
     def test_register_multiple_strikes(self):
-        self.rcm8cube.register_section('test1', section.StrikeSection(idx=5))
-        self.rcm8cube.register_section('test2', section.StrikeSection(idx=5))
-        self.rcm8cube.register_section('test3', section.StrikeSection(idx=8))
-        self.rcm8cube.register_section('test4', section.StrikeSection(idx=10))
+        self.rcm8cube.register_section(
+            'test1', section.StrikeSection(distance_idx=5))
+        self.rcm8cube.register_section(
+            'test2', section.StrikeSection(distance_idx=5))
+        self.rcm8cube.register_section(
+            'test3', section.StrikeSection(distance_idx=8))
+        self.rcm8cube.register_section(
+            'test4', section.StrikeSection(distance_idx=10))
         assert not self.rcm8cube.sections[
             'test1'] is self.rcm8cube.sections['test2']
         assert np.all(self.rcm8cube.sections['test1']['velocity'] ==
@@ -509,8 +552,10 @@ class TestCubesWithManySections:
                           self.rcm8cube.sections['test3']['velocity'])
 
     def test_register_strike_and_path(self):
-        self.rcm8cube.register_section('test1', section.StrikeSection(idx=5))
-        self.rcm8cube.register_section('test1a', section.StrikeSection(idx=5))
+        self.rcm8cube.register_section(
+            'test1', section.StrikeSection(distance_idx=5))
+        self.rcm8cube.register_section(
+            'test1a', section.StrikeSection(distance_idx=5))
         self.rcm8cube.register_section(
             'test2', section.PathSection(path=self.test_path))
         assert not self.rcm8cube.sections[
@@ -524,9 +569,9 @@ class TestCubesWithManySections:
 
     def test_show_trace_sections_multiple(self):
         self.rcm8cube.register_section(
-            'show_test1', section.StrikeSection(idx=5))
+            'show_test1', section.StrikeSection(distance_idx=5))
         self.rcm8cube.register_section(
-            'show_test2', section.StrikeSection(idx=50))
+            'show_test2', section.StrikeSection(distance_idx=50))
         fig, ax = plt.subplots(1, 2)
         self.rcm8cube.sections['show_test2'].show_trace('r--')
         self.rcm8cube.sections['show_test1'].show_trace('g--', ax=ax[0])
@@ -540,7 +585,7 @@ class TestSectionFromDataCubeNoStratigraphy:
     rcm8cube_nostrat = cube.DataCube(
         golf_path,
         coordinates={'x': 'y', 'y': 'x'})
-    rcm8cube_nostrat.register_section('test', section.StrikeSection(idx=5))
+    rcm8cube_nostrat.register_section('test', section.StrikeSection(distance_idx=5))
 
     def test_nostrat_getitem_explicit(self):
         s = self.rcm8cube_nostrat.sections['test'].__getitem__('velocity')
@@ -555,14 +600,14 @@ class TestSectionFromDataCubeNoStratigraphy:
             self.rcm8cube_nostrat.sections['test']['badvariablename']
 
     def test_nostrat_getitem_broken_cube(self):
-        sass = section.StrikeSection(idx=5)
+        sass = section.StrikeSection(distance_idx=5)
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass['velocity']
         # make a good section, then switch to invalidcube inside section
         temp_rcm8cube_nostrat = cube.DataCube(
             golf_path)
         temp_rcm8cube_nostrat.register_section(
-            'test', section.StrikeSection(idx=5))
+            'test', section.StrikeSection(distance_idx=5))
         temp_rcm8cube_nostrat.sections['test'].cube = 'badvalue!'
         with pytest.raises(TypeError):
             _ = temp_rcm8cube_nostrat.sections['test'].__getitem__('velocity')
@@ -621,7 +666,7 @@ class TestSectionFromDataCubeNoStratigraphy:
                                                     data='spacetime', ax=ax)
 
     def test_nostrat_show_shaded_spacetime_no_cube(self):
-        sass = section.StrikeSection(idx=5)
+        sass = section.StrikeSection(distance_idx=5)
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass.show('time', style='shaded',
                       data='spacetime')
@@ -676,7 +721,7 @@ class TestSectionFromDataCubeWithStratigraphy:
         golf_path,
         coordinates={'x': 'y', 'y': 'x'})
     rcm8cube.stratigraphy_from('eta', dz=0.1)
-    rcm8cube.register_section('test', section.StrikeSection(idx=5))
+    rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
 
     def test_withstrat_getitem_explicit(self):
         s = self.rcm8cube.sections['test'].__getitem__('velocity')
@@ -691,13 +736,13 @@ class TestSectionFromDataCubeWithStratigraphy:
             self.rcm8cube.sections['test']['badvariablename']
 
     def test_withstrat_getitem_broken_cube(self):
-        sass = section.StrikeSection(idx=5)
+        sass = section.StrikeSection(distance_idx=5)
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass['velocity']
         # make a good section, then switch to invalidcube inside section
         temp_rcm8cube = cube.DataCube(
             golf_path)
-        temp_rcm8cube.register_section('test', section.StrikeSection(idx=5))
+        temp_rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
         temp_rcm8cube.sections['test'].cube = 'badvalue!'
         with pytest.raises(TypeError):
             _ = temp_rcm8cube.sections['test'].__getitem__('velocity')
@@ -729,7 +774,7 @@ class TestSectionFromDataCubeWithStratigraphy:
         assert isinstance(_v, list)
 
     def test_withstrat_registered_StrikeSection_attributes(self):
-        assert np.all(self.rcm8cube.sections['test']._idx_trace[:, 0] == 5)
+        assert np.all(self.rcm8cube.sections['test'].trace_idx[:, 0] == 5)
         assert self.rcm8cube.sections['test'].s.size == self.rcm8cube.shape[2]
         assert len(self.rcm8cube.sections['test'].variables) > 0
         assert self.rcm8cube.sections['test'].y == 5
@@ -766,7 +811,7 @@ class TestSectionFromDataCubeWithStratigraphy:
                                             data='spacetime', ax=ax)
 
     def test_withstrat_show_shaded_spacetime_no_cube(self):
-        sass = section.StrikeSection(idx=5)
+        sass = section.StrikeSection(distance_idx=5)
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass.show('time', style='shaded',
                       data='spacetime')
@@ -818,8 +863,8 @@ class TestSectionFromStratigraphyCube:
         coordinates={'x': 'y', 'y': 'x'})
     sc8cube = cube.StratigraphyCube.from_DataCube(
         rcm8cube, dz=0.1)
-    rcm8cube.register_section('test', section.StrikeSection(idx=5))
-    sc8cube.register_section('test', section.StrikeSection(idx=5))
+    rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
+    sc8cube.register_section('test', section.StrikeSection(distance_idx=5))
 
     def test_strat_getitem_explicit(self):
         s = self.sc8cube.sections['test'].__getitem__('velocity')
@@ -834,13 +879,13 @@ class TestSectionFromStratigraphyCube:
             self.sc8cube.sections['test']['badvariablename']
 
     def test_strat_getitem_broken_cube(self):
-        sass = section.StrikeSection(idx=5)
+        sass = section.StrikeSection(distance_idx=5)
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass['velocity']
         # make a good section, then switch to invalidcube inside section
         temp_rcm8cube = cube.DataCube(
             golf_path)
-        temp_rcm8cube.register_section('test', section.StrikeSection(idx=5))
+        temp_rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
         temp_rcm8cube.sections['test'].cube = 'badvalue!'
         with pytest.raises(TypeError):
             _ = temp_rcm8cube.sections['test'].__getitem__('velocity')
@@ -856,8 +901,8 @@ class TestSectionFromStratigraphyCube:
         assert isinstance(self.sc8cube.sections['test'].trace, np.ndarray)
 
     def test_idx_trace(self):
-        assert isinstance(self.rcm8cube.sections['test']._idx_trace, np.ndarray)
-        assert isinstance(self.sc8cube.sections['test']._idx_trace, np.ndarray)
+        assert isinstance(self.rcm8cube.sections['test'].trace_idx, np.ndarray)
+        assert isinstance(self.sc8cube.sections['test'].trace_idx, np.ndarray)
 
     def test_s(self):
         assert isinstance(self.rcm8cube.sections['test'].s, xr.core.dataarray.DataArray)
@@ -881,7 +926,7 @@ class TestSectionFromStratigraphyCube:
                                                data='spacetime')
 
     def test_strat_show_shaded_spacetime_no_cube(self):
-        sass = section.StrikeSection(idx=5)
+        sass = section.StrikeSection(distance_idx=5)
         with pytest.raises(AttributeError, match=r'No cube connected.*.'):
             sass.show('time', style='shaded',
                       data='spacetime')
@@ -913,10 +958,11 @@ class TestSectionFromStratigraphyCube:
             self.sc8cube.sections['test'].show('time', style='lines',
                                                data='preserved')
 
-    @pytest.mark.xfail(reason='not yet decided best way to implement')
     def test_strat_show_lines_asstratigraphy(self):
-        self.sc8cube.sections['test'].show('time', style='lines',
-                                           data='stratigraphy')
+        # reason='not yet decided best way to implement'
+        with pytest.raises(NotImplementedError):
+            self.sc8cube.sections['test'].show('time', style='lines',
+                                               data='stratigraphy')
 
     def test_strat_show_bad_style(self):
         with pytest.raises(ValueError,
@@ -943,7 +989,7 @@ class TestSectionVariableNoStratigraphy:
     rcm8cube = cube.DataCube(
         golf_path,
         coordinates={'x': 'y', 'y': 'x'})
-    rcm8cube.register_section('test', section.StrikeSection(idx=5))
+    rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
     dsv = rcm8cube.sections['test']['velocity']
 
     def test_dsv_view_from(self):
@@ -976,7 +1022,7 @@ class TestSectionVariableWithStratigraphy:
         golf_path,
         coordinates={'x': 'y', 'y': 'x'})
     rcm8cube.stratigraphy_from('eta', dz=0.1)
-    rcm8cube.register_section('test', section.StrikeSection(idx=5))
+    rcm8cube.register_section('test', section.StrikeSection(distance_idx=5))
     dsv = rcm8cube.sections['test']['velocity']
 
     def test_dsv_knows_stratigraphy(self):
@@ -1005,7 +1051,7 @@ class TestSectionVariableStratigraphyCube:
         coordinates={'x': 'y', 'y': 'x'})
     sc8cube = cube.StratigraphyCube.from_DataCube(
         rcm8cube, dz=0.1)
-    sc8cube.register_section('test', section.StrikeSection(idx=5))
+    sc8cube.register_section('test', section.StrikeSection(distance_idx=5))
     ssv = sc8cube.sections['test']['velocity']
 
     def test_ssv_view_from(self):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -44,7 +44,7 @@ class TestLineToCells:
         assert (np.all(ret1 == ret2) and np.all(ret1 == ret3))
         assert ret1.shape[1] == 61
 
-    def test_positive_angle_inputs(self):
+    def test_quadrantI_angle_inputs(self):
         x0, y0, x1, y1 = 10, 10, 60, 92
         ret1 = utils.line_to_cells(np.array([[x0, y0], [x1, y1]]))
         ret2 = utils.line_to_cells((x0, y0), (x1, y1))
@@ -52,8 +52,35 @@ class TestLineToCells:
         ret1, ret2, ret3 = np.vstack(ret1), np.vstack(ret2), np.vstack(ret3)
         assert (np.all(ret1 == ret2) and np.all(ret1 == ret3))
         assert ret1.shape[1] == 83
+        # check line is sorted correctly: p0 --> p1
+        assert np.all(ret1[:, 0] == np.array([x0, y0]))
+        assert np.all(ret1[:, -1] == np.array([x1, y1]))
 
-    def test_negative_angle_inputs(self):
+    def test_quadrantII_angle_inputs(self):
+        x0, y0, x1, y1 = 80, 20, 40, 50
+        ret1 = utils.line_to_cells(np.array([[x0, y0], [x1, y1]]))
+        ret2 = utils.line_to_cells((x0, y0), (x1, y1))
+        ret3 = utils.line_to_cells(x0, y0, x1, y1)
+        ret1, ret2, ret3 = np.vstack(ret1), np.vstack(ret2), np.vstack(ret3)
+        assert (np.all(ret1 == ret2) and np.all(ret1 == ret3))
+        assert ret1.shape[1] == 41
+        # check line is sorted correctly: p0 --> p1
+        assert np.all(ret1[:, 0] == np.array([x0, y0]))
+        assert np.all(ret1[:, -1] == np.array([x1, y1]))
+
+    def test_quadrantIII_angle_inputs(self):
+        x0, y0, x1, y1 = 80, 70, 40, 40
+        ret1 = utils.line_to_cells(np.array([[x0, y0], [x1, y1]]))
+        ret2 = utils.line_to_cells((x0, y0), (x1, y1))
+        ret3 = utils.line_to_cells(x0, y0, x1, y1)
+        ret1, ret2, ret3 = np.vstack(ret1), np.vstack(ret2), np.vstack(ret3)
+        assert (np.all(ret1 == ret2) and np.all(ret1 == ret3))
+        assert ret1.shape[1] == 41
+        # check line is sorted correctly: p0 --> p1
+        assert np.all(ret1[:, 0] == np.array([x0, y0]))
+        assert np.all(ret1[:, -1] == np.array([x1, y1]))
+
+    def test_quadrantIV_angle_inputs(self):
         x0, y0, x1, y1 = 10, 80, 60, 30
         ret1 = utils.line_to_cells(np.array([[x0, y0], [x1, y1]]))
         ret2 = utils.line_to_cells((x0, y0), (x1, y1))
@@ -61,13 +88,15 @@ class TestLineToCells:
         ret1, ret2, ret3 = np.vstack(ret1), np.vstack(ret2), np.vstack(ret3)
         assert (np.all(ret1 == ret2) and np.all(ret1 == ret3))
         assert ret1.shape[1] == 51
+        assert np.all(ret1[:, 0] == np.array([x0, y0]))
+        assert np.all(ret1[:, -1] == np.array([x1, y1]))
 
     def test_bad_inputs(self):
         x0, y0, x1, y1 = 10, 10, 60, 92
-        with pytest.raises(TypeError):
-            ret = utils.line_to_cells(x0, y0, x1, y1, x0, y1)
+        with pytest.raises(TypeError, match=r'Length of input .*'):
+            _ = utils.line_to_cells(x0, y0, x1, y1, x0, y1)
         with pytest.raises(ValueError):
-            ret1 = utils.line_to_cells(
+            _ = utils.line_to_cells(
                 np.array([[x0, y0], [x1, y1], [x0, y1]]))
 
 


### PR DESCRIPTION
Refactored the inputs to sections (closes #34)

- [x] PathSection
- [x] StrikeSection
- [x] DipSection
- [x] CircularSection
- [x] RadialSection

Each section can take inputs as either dimensional coordinates or as indices. Each argument has a paired argument `xxxx_idx` that is the input variables. Documentation and tests updated,

**warning: this is a breaking change. The behavior of some input arguments has been maintained with a deprecation warning (e.g., `y` as input for a strike section), but others could not maintain backwards compatability (e.g., `radius` for a circular section now specified coordinates instead of indices and will likely result in an error without updating your own code).

Note: this PR also fixed a few issues with sections. Namely, `Path` and `Radial` sections would occasionally be drawn the wrong direction or have incorrect ordering.

Will also complete and closes #33