### PR TITLE
New data: aeolian dune field

### DIFF
--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -1,6 +1,7 @@
 
 import abc
 import os
+import copy
 from warnings import warn
 
 import xarray as xr
@@ -181,11 +182,11 @@ class NetCDFIO(BaseIO):
 
         # try to find if coordinates have been preconfigured
         _coords_list = list(_dataset.coords)
-        if set(['time', 'x', 'y']).issubset(set(_coords_list)):
+        if len(_coords_list) == 3:
             # the coordinates are preconfigured
             self.dataset = _dataset.set_coords(_coords_list)
-            self.dims = list(self.dataset.dims)
             self.coords = list(self.dataset.coords)
+            self.dims = copy.deepcopy(self.coords)
         elif set(['total_time', 'length', 'width']).issubset(set(_dataset.dims.keys())):
             # the coordinates are not set, but there are matching arrays
             # this is a legacy option, so issue a warning here

--- a/deltametrics/sample_data/__init__.py
+++ b/deltametrics/sample_data/__init__.py
@@ -1,8 +1,10 @@
 from .sample_data import (
     _get_golf_path,
+    _get_aeolian_path,
     _get_rcm8_path,
     _get_landsat_path,
     golf,
+    aeolian,
     rcm8,
     landsat,
 )

--- a/deltametrics/sample_data/registry.txt
+++ b/deltametrics/sample_data/registry.txt
@@ -1,3 +1,4 @@
 golf.zip 4da329fa6ac7cac903d509a39b7921000cd987dc6889ccc14aeedfdf6f89e090 https://zenodo.org/record/5570962/files/golf.zip?download=1
+swanson_aeolian_expt1.nc 76001cd9e8b5570f6830a30e650b211180a2813618bc283f810b639b8b95e424 https://figshare.com/ndownloader/files/31651322
 pyDeltaRCM_Output_8.nc 6c7e83bddc7043a2723ba8bb5ce056781eea246b0a3fe35ca26cfccda053c86b
 LandsatEx.hdf5 56c5b6b3931b1a1182d9037742a0dc338e93261b1c073f66c2803886b4e2739f

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -50,8 +50,8 @@ def golf():
     Data available at Zenodo, https://doi.org/10.5281/zenodo.4456143.
 
     Version history:
-    v1.1: 10.5281/zenodo.5570962
-    v1.0: 10.5281/zenodo.4456144
+      * v1.1: 10.5281/zenodo.5570962
+      * v1.0: 10.5281/zenodo.4456144
 
     .. plot::
 
@@ -65,8 +65,8 @@ def golf():
             ax[i].set_title('t = ' + str(t))
             ax[i].axes.get_xaxis().set_ticks([])
             ax[i].axes.get_yaxis().set_ticks([])
-        ax[0].set_ylabel('y-direction')
-        ax[0].set_xlabel('x-direction')
+        ax[0].set_ylabel('dim1 direction')
+        ax[0].set_xlabel('dim2 direction')
         plt.show()
     """
     golf_path = _get_golf_path()
@@ -94,21 +94,22 @@ def aeolian():
     Dune Topography. Math Geosci 49, 635–655
     (2017). https://doi.org/10.1007/s11004-016-9654-x
 
-    dataset reference: https://doi.org/10.6084/m9.figshare.17118827.v1
+    Dataset reference: https://doi.org/10.6084/m9.figshare.17118827.v1
 
     Details:
-        * default simualtion parameters were used.
-        * only the first 500 timesteps of the simulation were recorded into
-          the netcdf file.
-        * the ordering for "easting" and "northing" coordinates in the netCDF
-          file is opposite from the paper---the data are the same, but the
-          source region is along the second axis; thus the display is
-          different from the original paper.
-        * simulation used the model code included as a supplement to the paper
-          found here:
-          https://static-content.springer.com/esm/art:10.1007/s11004-016-9654-x/MediaObjects/11004_2016_9654_MOESM5_ESM.txt
-        * simulation was executed on 12/02/2021 with Matlab R2021a on Ubuntu
-          20.04.
+      * default simualtion parameters were used.
+      * only the first 500 timesteps of the simulation were recorded into
+        the netcdf file.
+      * the *ordering* for "easting" and "northing" coordinates in the
+        netCDF file is opposite from the paper---that is the source region
+        is along the second axis, i.e., ``dim1[source_regiom]==0``. The
+        display of this dataset is thus different from the original
+        paper, *but the data are the same*.
+      * simulation used the model code included as a supplement to the paper
+        found here:
+        https://static-content.springer.com/esm/art%3A10.1007%2Fs11004-016-9654-x/MediaObjects/11004_2016_9654_MOESM5_ESM.txt
+      * simulation was executed on 12/02/2021 with Matlab R2021a on Ubuntu
+        20.04.
 
     .. plot::
 
@@ -116,12 +117,14 @@ def aeolian():
         nt = 5
         ts = np.linspace(0, aeolian['eta'].shape[0]-1, num=nt, dtype=np.int)
 
-        fig, ax = plt.subplots(1, nt, figsize=(7, 5))
+        fig, ax = plt.subplots(1, nt, figsize=(8, 4))
         for i, t in enumerate(ts):
-            ax[i].imshow(aeolian['eta'][t, :, :], vmin=-4, vmax=5)
+            ax[i].imshow(aeolian['eta'][t, :, :], vmin=-5, vmax=7)
             ax[i].set_title('t = ' + str(t))
             ax[i].axes.get_xaxis().set_ticks([])
             ax[i].axes.get_yaxis().set_ticks([])
+        ax[0].set_ylabel('northing')
+        ax[0].set_xlabel('easting')
         plt.show()
     """
     aeolian_path = _get_aeolian_path()

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -77,6 +77,57 @@ def tdb12():
     raise NotImplementedError
 
 
+def _get_aeolian_path():
+    aeolian_path = REGISTRY.fetch('swanson_aeolian_expt1.nc')
+    return aeolian_path
+
+
+def aeolian():
+    """An aeolian dune field dataset.
+
+    This is a synthetic delta dataset generated from the Swanson et al.,
+    2017 "A Surface Model for Aeolian Dune Topography" numerical model. The
+    data have been subsetted, only keeping the first 500 saved timesteps, and
+    formatted into a netCDF file.
+
+    Swanson, T., Mohrig, D., Kocurek, G. et al. A Surface Model for Aeolian
+    Dune Topography. Math Geosci 49, 635–655
+    (2017). https://doi.org/10.1007/s11004-016-9654-x
+
+    dataset reference: https://doi.org/10.6084/m9.figshare.17118827.v1
+
+    Details:
+        * default simualtion parameters were used.
+        * only the first 500 timesteps of the simulation were recorded into
+          the netcdf file.
+        * the ordering for "easting" and "northing" coordinates in the netCDF
+          file is opposite from the paper---the data are the same, but the
+          source region is along the second axis; thus the display is
+          different from the original paper.
+        * simulation used the model code included as a supplement to the paper
+          found here:
+          https://static-content.springer.com/esm/art:10.1007/s11004-016-9654-x/MediaObjects/11004_2016_9654_MOESM5_ESM.txt
+        * simulation was executed on 12/02/2021 with Matlab R2021a on Ubuntu
+          20.04.
+
+    .. plot::
+
+        aeolian = dm.sample_data.aeolian()
+        nt = 5
+        ts = np.linspace(0, aeolian['eta'].shape[0]-1, num=nt, dtype=np.int)
+
+        fig, ax = plt.subplots(1, nt, figsize=(7, 5))
+        for i, t in enumerate(ts):
+            ax[i].imshow(aeolian['eta'][t, :, :], vmin=-4, vmax=5)
+            ax[i].set_title('t = ' + str(t))
+            ax[i].axes.get_xaxis().set_ticks([])
+            ax[i].axes.get_yaxis().set_ticks([])
+        plt.show()
+    """
+    aeolian_path = _get_aeolian_path()
+    return cube.DataCube(aeolian_path)
+
+
 def _get_rcm8_path():
     rcm8_path = REGISTRY.fetch('pyDeltaRCM_Output_8.nc')
     return rcm8_path

--- a/docs/source/reference/sample_data/index.rst
+++ b/docs/source/reference/sample_data/index.rst
@@ -34,8 +34,9 @@ Example data cubes
 ------------------
 
 .. autofunction:: golf
-.. autofunction:: rcm8
+.. autofunction:: aeolian
 .. autofunction:: landsat
+.. autofunction:: rcm8
 
 
 Paths to data files


### PR DESCRIPTION
add some new data from a different domain.

This data is from an aeolian dune field numerical model.

![image](https://user-images.githubusercontent.com/8801322/144616053-f75f360c-c341-4030-b240-ebf7447d696e.png)

The main goal with this contribution is to have a dataset to test and develop with that is different from the pyDeltaRCM outputs.
This dataset:
* uses different names for the coordinates (easting and northing)
* does not have anything in the `meta` field
* is a dune field, so it's not a delta at all

hoping this helps move us towards being more flexible for domains other than deltas (and then change the name 😀)

NOTE: This did help me find a bug with the way we pulled coordinate names, already! So that's cool, and I fixed it.