### PR TITLE
add a DepositMask

### DIFF
--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -2365,6 +2365,11 @@ class DepositMask(BaseMask):
     """Create a `DepositMask` from an array.
 
     This is a Mask for where any sediment has been deposited.
+
+    .. note::
+
+        This class might be improved by reimplementing as a subclass of
+        `ThresholdValueMask`.
     
     Examples
     --------
@@ -2375,10 +2380,10 @@ class DepositMask(BaseMask):
         :include-source:
 
         >>> golfcube = dm.sample_data.golf()
-
         >>> deposit_mask = dm.mask.DepositMask(
-        >>> golfcube['eta'][-1, :, :], golfcube['eta'][0, :, :])
-
+        ...     golfcube['eta'][-1, :, :],
+        ...     background_value=golfcube['eta'][0, :, :])
+        >>>
         >>> fig, ax = plt.subplots(1, 2)
         >>> golfcube.quick_show('eta', ax=ax[0])
         >>> deposit_mask.show(ax=ax[1])
@@ -2413,7 +2418,9 @@ class DepositMask(BaseMask):
         `elevation` is greater than the `background_value`, outside
         some tolerance:
             
-            .. code:: np.abs(elevation - background_value) > elevation_tolerance   # noqa: E501
+        .. code::
+
+            np.abs(elevation - background_value) > elevation_tolerance   # noqa: E501
         
         However, using the mask provides benefits of array tracking and
         various integrations with other masks and functions.

--- a/docs/source/reference/mask/index.rst
+++ b/docs/source/reference/mask/index.rst
@@ -29,4 +29,5 @@ Mask types
     CenterlineMask
     BaseMask
     ThresholdValueMask
+    DepositMask
     GeometricMask

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1713,3 +1713,104 @@ class TestGeometricMask:
         gmsk = mask.GeometricMask(arr)
         with pytest.raises(ValueError):
             gmsk.angular(0, np.pi/2)
+
+
+class TestDepositMask:
+    """Tests associated with the mask.CenterlineMask class."""
+
+    def test_default_tolerance_no_background(self):
+        """Test that instantiation works for an array."""
+        # define the mask
+        depositmask = mask.DepositMask(
+            golfcube['eta'][-1, :, :])
+
+        compval = (0 + depositmask._elevation_tolerance)
+
+        # make assertions
+        assert depositmask._elevation_tolerance == 0.1  # check default
+        assert depositmask._mask.data.sum() == (golfcube['eta'][-1, :, :] > compval).data.sum()
+
+        assert depositmask._input_flag == 'array'
+        assert depositmask.mask_type == 'deposit'
+        assert depositmask._mask.dtype == bool
+
+    def test_default_tolerance_background_array(self):
+        """Test that instantiation works for an array."""
+        # define the mask
+        depositmask = mask.DepositMask(
+            golfcube['eta'][-1, :, :],
+            background_value=golfcube['eta'][0, :, :])
+
+        with pytest.raises(TypeError):
+            # fails without specifying key name
+            _ = mask.DepositMask(
+                golfcube['eta'][-1, :, :],
+                golfcube['eta'][0, :, :])
+
+        # make assertions
+        assert depositmask._elevation_tolerance == 0.1  # check default
+
+        assert depositmask._input_flag == 'array'
+        assert depositmask.mask_type == 'deposit'
+        assert depositmask._mask.dtype == bool
+
+    def test_default_tolerance_background_float(self):
+        """Test that instantiation works for an array."""
+        # define the mask
+        depositmask = mask.DepositMask(
+            golfcube['eta'][-1, :, :],
+            background_value=-1)
+
+        with pytest.raises(TypeError):
+            # fails without specifying key name
+            _ = mask.DepositMask(
+                golfcube['eta'][-1, :, :],
+                -1)
+
+        compval = (-1 + depositmask._elevation_tolerance)
+
+        assert depositmask._mask.data.sum() == (golfcube['eta'][-1, :, :] > compval).data.sum()
+        assert depositmask._elevation_tolerance == 0.1  # check default
+
+        assert depositmask._input_flag == 'array'
+        assert depositmask.mask_type == 'deposit'
+        assert depositmask._mask.dtype == bool
+
+    def test_elevation_tolerance_background_array(self):
+        defaultdepositmask = mask.DepositMask(
+            golfcube['eta'][-1, :, :],
+            background_value=golfcube['eta'][0, :, :])
+
+        depositmask = mask.DepositMask(
+            golfcube['eta'][-1, :, :],
+            background_value=golfcube['eta'][0, :, :],
+            elevation_tolerance=1)
+
+        assert depositmask._input_flag == 'array'
+        assert depositmask.mask_type == 'deposit'
+        assert depositmask._mask.dtype == bool
+        assert depositmask._elevation_tolerance == 1  # check NOT default
+        assert defaultdepositmask._mask.sum() > depositmask._mask.sum()
+
+    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
+                       reason='Have not implemented pathway.')
+    def test_default_vals_cube(self):
+        """Test that instantiation works for an array."""
+        # define the mask
+        depositmask = mask.DepositMask(rcm8cube, t=-1)
+        # make assertions
+        assert depositmask._input_flag == 'cube'
+        assert depositmask.mask_type == 'deposit'
+        assert depositmask._mask.dtype == bool
+
+    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
+                       reason='Have not implemented pathway.')
+    def test_default_vals_cubewithmeta(self):
+        """Test that instantiation works for an array."""
+        # define the mask
+        depositmask = mask.DepositMask(golfcube, t=-1)
+        # make assertions
+        assert depositmask._input_flag == 'cube'
+        assert depositmask.mask_type == 'deposit'
+        assert depositmask._mask.dtype == bool
+   


### PR DESCRIPTION
add a basic deposit mask function for quickly determining where sediment has been deposited, and having the benefits of type checking and handling  mask-dimension and plotting.

Example: 
![image](https://user-images.githubusercontent.com/8801322/148616415-be28414c-d046-4c82-a299-d45829c0dca5.png)
