### PR TITLE
close issue #97

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
@@ -48,10 +48,10 @@ jobs:
       uses: actions/checkout@v2
       with:
         persist-credentials: false
-    - name: Set up Python 3.8
+    - name: Set up Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1632,7 +1632,7 @@ def _custom_closing(img, disksize):
     _iter = 0  # count number of closings, cap at 100
     while (_changed != 0) and (_iter < 100):
         _iter += 1
-        _newimg = morphology.binary_closing(img, selem=disk)
+        _newimg = morphology.binary_closing(img, footprint=disk)
         _changed = np.sum(_newimg.astype(float)-img.astype(float))
         _closed = _newimg
     return _closed

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ scipy>=1.5
 netCDF4
 pyyaml>=5.1
 Shapely
-scikit-image
+scikit-image>=0.19
 xarray
 pooch
 numba


### PR DESCRIPTION
replaces the 'selem' kwarg for the scikit-image binary closing method with the new
'footprint' argument. sets the minimum version for scikit-image to 0.19 in the
requirements.txt file which is the first version that has the 'footprint' argument.

closes #97