### PR TITLE
Fix eg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,12 +8,13 @@ DeltaMetrics
 .. image:: https://codecov.io/gh/DeltaRCM/DeltaMetrics/branch/develop/graph/badge.svg
   :target: https://codecov.io/gh/DeltaRCM/DeltaMetrics
 
-DeltaMetrics is a Python package for manipulating depositional system data cubes.
-In particular, DeltaMetrics has robust objects and routines designed to help organize, visualize, and analyze topography and sedimentological timeseries data deltaic systems (e.g., the pyDeltaRCM numerical model and laboratory delta experiments).
+*DeltaMetrics* is a Python package for manipulating depositional system data cubes.
+The package has robust objects and routines designed to help organize, visualize, and analyze topography and sedimentological timeseries data.
+*DeltaMetrics* works especially well with data from deltaic systems (e.g., the `pyDeltaRCM numerical model <https://github.com/DeltaRCM/pyDeltaRCM>`_  and laboratory delta experiments).
 
 `Full documentation here <https://deltarcm.org/DeltaMetrics/index.html>`_.
 
 
 .. figure:: https://deltarcm.org/DeltaMetrics/_images/cover.png
 
-  A view of bed elevation on a modeled deltaic deposit in `Planform`, and a cross `StrikeSection` view of the timing of sediment deposition in stratigraphy.
+  A view of bed elevation on a modeled deltaic deposit in ``Planform``, and a cross ``StrikeSection`` view of the timing of sediment deposition in stratigraphy.

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -356,6 +356,19 @@ class BaseCube(abc.ABC):
         """Number of elements in data (HxLxW)."""
         return (self.H, self.L, self.W)
 
+    @property
+    def extent(self):
+        """The limits of the dim1 by dim2 plane.
+
+        Useful for plotting.
+        """
+        _extent = [
+            self.dim2_coords[0],                         # dim1, 0
+            self.dim2_coords[-1] + self.dim2_coords[1],  # dim1, end + dx
+            self.dim1_coords[-1] + self.dim1_coords[1],  # dim0, end + dx
+            self.dim1_coords[0]]                         # dim0, 0
+        return _extent
+
     def export_frozen_variable(self, var, return_cube=False):
         """Export a cube with frozen values.
 

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -1202,7 +1202,12 @@ class ShorelineMask(BaseMask):
 
     @staticmethod
     def from_mask(UnknownMask, **kwargs):
-        """Create a ShorelineMask directly from an ElevationMask.
+        """Create a ShorelineMask directly from an :obj:`ElevationMask`.
+
+        .. hint::
+
+            Optionally, use the `method` flag to control how the
+            mask is created.
         """
         if not isinstance(UnknownMask, ElevationMask):
             # make intermediate shoreline mask

--- a/docs/source/guides/examples/planforms/planform_intro.rst
+++ b/docs/source/guides/examples/planforms/planform_intro.rst
@@ -15,15 +15,10 @@ For each we start with the same example dataset, and use the elevation data at t
 
     golfcube = dm.sample_data.golf()
 
-    plt.imshow(golfcube['eta'][-1, :, :])
-    plt.colorbar()
-    plt.title('Final Elevation Data')
+    fig, ax = plt.subplots()
+    golfcube.quick_show('eta', idx=-1, ax=ax)
+    ax.set_title('Final Elevation Data')
     plt.show()
-
-.. plot::
-    :context:
-
-    plt.close()
 
 The OpeningAnglePlanform
 ------------------------
@@ -33,7 +28,7 @@ This planform object is based around the Opening Angle Method [1]_.
 The `OpeningAnglePlanform` can be created directly from elevation data:
 
 .. plot::
-    :context:
+    :context: close-figs
     :include-source:
 
     golfcube = dm.sample_data.golf()
@@ -47,18 +42,10 @@ In the case of the `OpeningAnglePlanform`, the `composite_array` is the "sea ang
     :context:
     :include-source:
 
-    plt.imshow(OAP.composite_array)
-    plt.colorbar()
+    fig, ax = plt.subplots()
+    im = ax.imshow(OAP.composite_array)
+    dm.plot.append_colorbar(im, ax=ax)
     plt.show()
-
-.. plot::
-    :context:
-
-    plt.close()
-
-.. todo::
-
-  Embellish the example
 
 .. [1] Shaw, J. B., Wolinsky, M. A., Paola, C., & Voller, V. R. (2008). An image‐based method for shoreline mapping on complex coasts. Geophysical Research Letters, 35(12).
 
@@ -70,7 +57,7 @@ This planform object uses mathematical morphology to identify the delta planform
 The `MorphologicalPlanform` can also be created directly from elevation data:
 
 .. plot::
-    :context:
+    :context: close-figs
     :include-source:
 
     MP = dm.plan.MorphologicalPlanform.from_elevation_data(
@@ -82,18 +69,15 @@ In this case, the `composite_array` attribute of the planform represents the inv
     :context:
     :include-source:
 
-    plt.imshow(MP.composite_array)
-    plt.colorbar()
+    fig, ax = plt.subplots()
+    im = ax.imshow(MP.composite_array)
+    dm.plot.append_colorbar(im, ax=ax)
     plt.show()
 
 .. plot::
     :context:
 
     plt.close()
-
-.. todo::
-
-  Embellish example
 
 .. [2] Geleynse, N., Voller, V. R., Paola, C., & Ganti, V. (2012). Characterization of river delta shorelines. Geophysical research letters, 39(17).
 
@@ -116,19 +100,19 @@ Of course the two methods are different, so the shorelines identified will also 
     SM_from_MPM = dm.mask.ShorelineMask.from_Planform(
       MP, contour_threshold=0.75)
 
-    fig, ax = plt.subplots(1, 3, figsize=(10, 5), dpi=300)
+    fig, ax = plt.subplots(1, 3, figsize=(10, 5))
 
-    ax[0].imshow(SM_from_OAM.mask, interpolation=None)
+    SM_from_OAM.show(ax=ax[0])
     ax[0].set_title('Shoreline from OAM')
 
-    ax[1].imshow(SM_from_MPM.mask, interpolation=None)
+    SM_from_MPM.show(ax=ax[1])
     ax[1].set_title('Shoreline from MPM')
 
-    d_plot = ax[2].imshow(
+    diff_im = ax[2].imshow(
       SM_from_OAM.mask.astype(float) - SM_from_MPM.mask.astype(float),
       interpolation=None, cmap='bone')
     ax[2].set_title('OAM shoreline - MPM shoreline')
-    plt.colorbar(d_plot, ax=ax[2], fraction=0.05)
+    dm.plot.append_colorbar(diff_im, ax=ax[2])
 
     plt.tight_layout()
     plt.show()

--- a/docs/source/guides/examples/planforms/planform_intro.rst
+++ b/docs/source/guides/examples/planforms/planform_intro.rst
@@ -74,7 +74,7 @@ The `MorphologicalPlanform` can also be created directly from elevation data:
     :include-source:
 
     MP = dm.plan.MorphologicalPlanform.from_elevation_data(
-      golfcube['eta'][-1, :, :], elevation_threshold=0, max_disk=5)
+      golfcube['eta'][-1, :, :], elevation_threshold=0, max_disk=8)
 
 In this case, the `composite_array` attribute of the planform represents the inverse of the average pixel value when different sized disks are used to perform the binary closing on the elevation data.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,8 +10,9 @@ DeltaMetrics
 .. image:: https://codecov.io/gh/DeltaRCM/DeltaMetrics/branch/develop/graph/badge.svg
   :target: https://codecov.io/gh/DeltaRCM/DeltaMetrics
 
-DeltaMetrics is a Python package for manipulating depositional system data cubes.
-In particular, DeltaMetrics has robust objects and routines designed to help organize, visualize, and analyze topography and sedimentological timeseries data deltaic systems (e.g., the pyDeltaRCM numerical model and laboratory delta experiments).
+*DeltaMetrics* is a Python package for manipulating depositional system data cubes.
+The package has robust objects and routines designed to help organize, visualize, and analyze topography and sedimentological timeseries data.
+*DeltaMetrics* works especially well with data from deltaic systems (e.g., the `pyDeltaRCM numerical model <https://github.com/DeltaRCM/pyDeltaRCM>`_  and laboratory delta experiments).
 
 .. plot:: guides/cover.py
 


### PR DESCRIPTION
Fix the example broken in #103, easy fix. Just needs a value to better reflect the width of the mouth.

before:
![image](https://user-images.githubusercontent.com/8801322/157113431-53dc0092-ed57-4f46-8f74-68595789fe37.png)


after:
![image](https://user-images.githubusercontent.com/8801322/157113341-98f71f2f-32a5-46a6-bde8-5d67e4611aa0.png)


One option might be to add a check in the [mask creating bits here](https://github.com/DeltaRCM/DeltaMetrics/blob/a386f0b3b98ff61ea976e33ac2842148094cc173/deltametrics/mask.py#L1479) to check if there are multiple contours returned for the threshold selected? We could at least raise a warning that the mask might not be as expected because two contours were identified (and suggest increasing the max_disk value). 

Related: might be helpful to raise a warning if the `contour_threshold` is greater than any values in the field being contoured. This would be helpful here to say MPM field is between 0 and 1, so select a threshold in there?

Thoughts?

