### PR TITLE
connect varset for StratigraphyCube.from_DataCube to inherit the vars…

### DIFF
--- a/deltametrics/_version.py
+++ b/deltametrics/_version.py
@@ -3,4 +3,4 @@ def __version__():
     """
     Private version declaration, gets assigned to dm.__version__ during import
     """
-    return '0.3.1'
+    return '0.3.2'

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -813,6 +813,7 @@ class StratigraphyCube(BaseCube):
             The new `StratigraphyCube` instance.
         """
         return StratigraphyCube(DataCubeInstance,
+                                varset=DataCubeInstance.varset,
                                 stratigraphy_from=stratigraphy_from,
                                 dz=dz, z=z, nz=nz)
 

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -364,6 +364,12 @@ class TestStratigraphyCube:
         frzn = self.fixedstratigraphycube.export_frozen_variable('time')
         assert frzn.ndim == 3
 
+    def test_StratigraphyCube_inherit_varset(self):
+        # when creating from DataCube, varset should be inherited
+        tempsc = cube.StratigraphyCube.from_DataCube(
+            self.fixeddatacube, dz=1)
+        assert tempsc.varset is self.fixeddatacube.varset
+
 
 class TestFrozenStratigraphyCube:
 


### PR DESCRIPTION
connect varset for StratigraphyCube.from_DataCube to inherit the varset that the originating DataCube uses.

Demonstration: 
The following test previously failed, this PR makes this test pass!

```python
fixeddatacube = cube.DataCube(golf_path)

def test_StratigraphyCube_inherit_varset(self):
    # when creating from DataCube, varset should be inherited
    tempsc = cube.StratigraphyCube.from_DataCube(
        fixeddatacube, dz=1)
    assert tempsc.varset is fixeddatacube.varset
```