### PR TITLE
create a default VariableInfo for attributes that are not known to the cube

### DIFF
--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -252,6 +252,7 @@ class VariableSet(object):
 
     @property
     def variables(self):
+        """Variables known to the VariableSet."""
         return self._variables
 
     def __getitem__(self, var):
@@ -261,9 +262,22 @@ class VariableSet(object):
         slicing the VariableSet with a string matching the VariableInfo `name`
         field. This enables accessing variables in evaluation, rather than
         explicit typing of variable names.
-        """
 
-        return self.__getattribute__(var)
+        Parameters
+        ----------
+        variable : :obj:`str`
+            Which variable to get the `VariableInfo` for.
+
+        .. note::
+
+            If `variable` is not identified in the VariableSet, then a default
+            instance of :obj:`VariableInfo` is instantiated with the variable
+            name and returned.
+        """
+        if var in self._variables:
+            return self.__getattribute__(var)
+        else:
+            return VariableInfo(var)
 
     def __setattr__(self, key, var):
         """Set, with check for types.
@@ -275,6 +289,8 @@ class VariableSet(object):
         else:
             if type(var) is VariableInfo or var is None:
                 object.__setattr__(self, key, var)
+                # add it to the list of variables
+                self._variables.append(key)
             else:
                 raise TypeError(
                     'Can only set attributes of type VariableInfo.')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -117,17 +117,21 @@ class TestVariableSet:
         vi = plot.VariableInfo('depth', vmin=-9999)
         vs.depth = vi
         assert vs.depth.vmin == -9999
+        assert vs['depth'].vmin == -9999
 
     def test_VariableSet_add_unknown_VariableInfo(self):
         vs = plot.VariableSet()
         vi = plot.VariableInfo('fakevariable', vmin=-9999)
         vs.fakevariable = vi
         assert vs.fakevariable.vmin == -9999
+        assert 'fakevariable' in vs.variables
+        assert vs['fakevariable'].vmin == -9999
 
     def test_VariableSet_set_known_VariableInfo_direct(self):
         vs = plot.VariableSet()
         vs.depth.vmin = -9999
         assert vs.depth.vmin == -9999
+        assert vs['depth'].vmin == -9999
 
     def test_VariableSet_change_then_default(self):
         vs = plot.VariableSet()
@@ -148,6 +152,15 @@ class TestVariableSet:
         vs = plot.VariableSet()
         with pytest.raises(TypeError):
             vs.fakevariable = 'Yellow!'
+
+    def test_get_unknown_notadded_variable(self):
+        # should return a default VariableInfo with name field
+        vs = plot.VariableSet()
+        got = vs['fakevariable']
+        assert got.name == 'fakevariable'
+        # NOTE: this does not work with attribute accessing
+        with pytest.raises(AttributeError):
+            _ = vs.fakevariable
 
 
 class TestAppendColorbar:


### PR DESCRIPTION
## before
When trying to style a variable that is not known the cube but exists in the underlying data file:
```
cube.quick_show('accumulate')
AttributeError
```

## after
When trying to style a variable that is not known the cube but exists in the underlying data file:
```
cube.quick_show('accumulate')
```
Shows the attribute `accumulate` using a default instance of `VariableInfo` with `name` specified as the variable name. Custom styling is still supported by assigning those attributes to the `VariableSet` during instantiation, but is not required any more.