### PR TITLE
add style kilometer tick formatter and axes formatter function.

### DIFF
--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -624,6 +624,67 @@ def append_colorbar(ci, ax, size=2, pad=2, labelsize=9, **kwargs):
 
     return cb
 
+def style_axes_km(*args):
+    """Style axes with kilometers, when initially set as meters.
+
+    This function can be used two ways. Passing an `Axes` object as the first
+    argument and optionally a string specifying `'x'`, `'y'`, or `'xy'`
+    [default] will chnage the appearance of the `Axes` object. Alternatively,
+    the function can be specified as the `ticker` function when setting a
+    label formatter.
+
+    Parameters
+    ----------
+    ax : :obj:`matplotlib.axes.Axes`
+        Axes object to format
+
+    which : :obj:`str`, optional
+        Which axes to style as kilometers. Default is `xy`, but optionally
+        pass `x` or `y` to only style one axis.
+
+    x : :obj:`float`
+        If using as a function to format labels, the tick mark location.
+
+    Examples
+    --------
+
+    .. plot::
+        :include-source:
+        :context: reset
+
+        golf = dm.sample_data.golf()
+
+        fig, ax = plt.subplots(
+            3, 1,
+            gridspec_kw=dict(hspace=0.5))
+        golf.quick_show('eta', ax=ax[0], ticks=True)
+
+        golf.quick_show('eta', ax=ax[1], ticks=True)
+        dm.plot.style_axes_km(ax[1])
+
+        golf.quick_show('eta', axis=1, idx=10, ax=ax[2])
+        ax[2].xaxis.set_major_formatter(dm.plot.style_axes_km)
+        # OR use: dm.plot.style_axes_km(ax[2], 'x')
+
+        plt.show()
+    """
+    if isinstance(args[0], matplotlib.axes.Axes):
+        ax = args[0]
+        if len(args) > 1:
+            which = args[1]
+        else:
+            # default is to apply to both xy
+            which = 'xy'
+        # recursive calls to this func!
+        if 'x' in which:
+            ax.xaxis.set_major_formatter(style_axes_km)
+        if 'y' in which:
+            ax.yaxis.set_major_formatter(style_axes_km)
+
+    else:
+        v = args[0]
+        return f'{v / 1000.:g}'
+
 
 def get_display_arrays(VarInst, data=None):
     """Get arrays for display of Variables.

--- a/docs/source/reference/plot/index.rst
+++ b/docs/source/reference/plot/index.rst
@@ -52,6 +52,9 @@ Mostly, these functions provide a component of a plot.
 .. autofunction:: aerial_view
 .. autofunction:: overlay_sparse_array
 
+.. autofunction:: style_axes_km
+.. autofunction:: append_colorbar
+
 
 DeltaMetrics plot routines
 ==========================
@@ -77,7 +80,6 @@ Plotting utility functions
 
 These functions are mostly used internally.
 
-.. autofunction:: append_colorbar
 .. autofunction:: get_display_arrays
 .. autofunction:: get_display_lines
 .. autofunction:: get_display_limits

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -196,6 +196,41 @@ class TestAppendColorbar:
         assert cb.formatter is _formatter
 
 
+class TestStyleAxesKm:
+
+    def test_style_axes_km_ax(self):
+
+        fig, ax = plt.subplots(1, 6)
+        plot.style_axes_km(ax[0]) # both
+        plot.style_axes_km(ax[1], 'x')  # x only
+        plot.style_axes_km(ax[2], 'y')  # y only
+        plot.style_axes_km(ax[3], 'xy') # both
+        plot.style_axes_km(ax[4], 'z')  # do nothing
+        ax[5].xaxis.set_major_formatter(plot.style_axes_km)  # x only
+
+        # check that the formatter has been set (or not)
+        #   note, returns '' if formatter not changed
+        assert ax[0].xaxis.get_major_formatter()(1000) == '1'
+        assert ax[0].yaxis.get_major_formatter()(1000) == '1'
+
+        assert ax[1].xaxis.get_major_formatter()(1000) == '1'
+        assert ax[1].yaxis.get_major_formatter()(1000) == ''
+
+        assert ax[2].xaxis.get_major_formatter()(1000) == ''
+        assert ax[2].yaxis.get_major_formatter()(1000) == '1'
+
+        assert ax[3].xaxis.get_major_formatter()(1000) == '1'
+        assert ax[3].yaxis.get_major_formatter()(1000) == '1'
+
+        assert ax[4].xaxis.get_major_formatter()(1000) == ''
+        assert ax[4].yaxis.get_major_formatter()(1000) == ''
+
+        assert ax[5].xaxis.get_major_formatter()(1000) == '1'
+        assert ax[5].yaxis.get_major_formatter()(1000) == ''
+
+        plt.close()
+
+
 class TestFillSteps:
     """Test the `_fill_steps` function."""
 


### PR DESCRIPTION
A simple utility function for plotting, that changes axes tick labels from meters to kilometers. I constantly find myself wanting this as a function, and so copying and pasting it from one notebook to the next or googling to recreate it. Still, I'm not sure if it's too specific to my needs to belong in the package...

![image](https://user-images.githubusercontent.com/8801322/175659586-827bfbad-f109-4a54-9668-57e599d74e82.png)

Todo:
- [x] tests