### PR TITLE
update deploy yaml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,11 +17,12 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+        pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
updates the deploy.yml file to match what we do in pyDeltaRCM.

zenodo integration has been set-up and toggled on so the next release should automatically archive on zenodo and get a DOI

@amoodie the DeltaMetrics repository just needs the pypi secrets before we trigger a new release and have this workflow run (maybe we do that before merging this and use this PR to increment the version too...)