### PR TITLE
Strat display

### DIFF
--- a/deltametrics/_version.py
+++ b/deltametrics/_version.py
@@ -3,4 +3,4 @@ def __version__():
     """
     Private version declaration, gets assigned to dm.__version__ during import
     """
-    return '0.3.3'
+    return '0.4.0'

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -737,13 +737,32 @@ def get_display_arrays(VarInst, data=None):
             _S, _Z = np.meshgrid(_s, _z)
             return VarInst.strat.as_preserved(), _S, _Z
         elif data in VarInst.strat._stratigraphy_names:
+            # for data sections and mesh quick strat display
+            #   there are a fair number of stylistic quirks here,
+            #   do not use this representation of the data for any
+            #   science calculations!
+
+            # make the sparse array dense
             _sp = VarInst.strat.as_stratigraphy()
-            _den = _sp.toarray()  # .view(section.DataSectionVariable)
+            _den = _sp.toarray()
+
+            # grab the y values for the array
             _arr_Y = VarInst.strat.strat_attr['psvd_flld'][:_sp.shape[0], ...]
+
+            # fix the bottom rows
+            _den[0, ...] = _den[1, ...]
+            _arr_Y[0, ...] = _arr_Y[1, ...]
+
+            # fix the dense values at tops
+            # not figured this out yet...
+
+            # pad the arrays to be data+1 in both dims
             _arr_X = np.tile(VarInst['s'], (_sp.shape[0], 1))
             _arr_Y = np.pad(_arr_Y, ((0, 0), (0, 1)), mode='edge')
             _z = VarInst[VarInst.dims[0]]
-            _p = np.min(_arr_Y) * np.ones((_arr_Y.shape[1]))  # prepend with base
+
+            # prepend the data with the lowest depth recorded to fill out image
+            _p = np.min(_arr_Y) * np.ones((_arr_Y.shape[1]))  # prepend base
             _arr_Y = np.vstack((_p, _arr_Y))
             _arr_X = np.pad(_arr_X, ((0, 1), (0, 1)), mode='edge')
             return _den, _arr_X, _arr_Y

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -722,18 +722,31 @@ def get_display_arrays(VarInst, data=None):
         # #  DataSection  # #
         data = data or 'spacetime'
         if data in VarInst.strat._spacetime_names:
-            _S, _Z = np.meshgrid(VarInst['s'], VarInst[VarInst.dims[0]])
+            _z = VarInst[VarInst.dims[0]]
+            _z = np.append(_z, _z[-1])
+            _s = VarInst['s']
+            _s = np.append(_s, _s[-1])
+            _S, _Z = np.meshgrid(_s, _z)
             return VarInst.values, _S, _Z
         elif data in VarInst.strat._preserved_names:
             VarInst.strat._check_knows_spacetime()
-            _S, _Z = np.meshgrid(VarInst['s'], VarInst[VarInst.dims[0]])
+            _z = VarInst[VarInst.dims[0]]
+            _z = np.append(_z, _z[-1])
+            _s = VarInst['s']
+            _s = np.append(_s, _s[-1])
+            _S, _Z = np.meshgrid(_s, _z)
             return VarInst.strat.as_preserved(), _S, _Z
         elif data in VarInst.strat._stratigraphy_names:
             _sp = VarInst.strat.as_stratigraphy()
             _den = _sp.toarray()  # .view(section.DataSectionVariable)
             _arr_Y = VarInst.strat.strat_attr['psvd_flld'][:_sp.shape[0], ...]
             _arr_X = np.tile(VarInst['s'], (_sp.shape[0], 1))
-            return _den[1:, 1:], _arr_X, _arr_Y
+            _arr_Y = np.pad(_arr_Y, ((0, 0), (0, 1)), mode='edge')
+            _z = VarInst[VarInst.dims[0]]
+            _p = np.min(_arr_Y) * np.ones((_arr_Y.shape[1]))  # prepend with base
+            _arr_Y = np.vstack((_p, _arr_Y))
+            _arr_X = np.pad(_arr_X, ((0, 1), (0, 1)), mode='edge')
+            return _den, _arr_X, _arr_Y
         else:
             raise ValueError('Bad data argument: %s' % str(data))
 
@@ -745,7 +758,11 @@ def get_display_arrays(VarInst, data=None):
         elif data in VarInst.strat._preserved_names:
             VarInst.strat._check_knows_spacetime()  # always False
         elif data in VarInst.strat._stratigraphy_names:
-            _S, _Z = np.meshgrid(VarInst['s'], VarInst[VarInst.dims[0]])
+            _z = VarInst[VarInst.dims[0]]
+            _z = np.append(_z, _z[-1])
+            _s = VarInst['s']
+            _s = np.append(_s, _s[-1])
+            _S, _Z = np.meshgrid(_s, _z)
             return VarInst, _S, _Z
         else:
             raise ValueError('Bad data argument: %s' % str(data))
@@ -1026,12 +1043,14 @@ def show_one_dimensional_trajectory_to_strata(e, sigma_dist=None,
         e = strat._adjust_elevation_by_subsidence(e_in, sigma_dist)
     s, p = strat._compute_elevation_to_preservation(e)  # strat, preservation
     z = strat._determine_strat_coordinates(e, dz=dz, z=z, nz=nz)  # vert coordinates
+    z_disp = np.append(z, z[-1])
     sc, dc = strat._compute_preservation_to_cube(s, z)
     lst = np.argmin(s < s[-1])  # last elevation
 
     c = np.full_like(z, np.nan)
     c[sc[:, 0]] = t[dc[:, 0]]
     cp = np.tile(c, (2, 1)).T
+    cp = np.atleast_2d(c).T
 
     # make the plots
     if not ax:
@@ -1060,17 +1079,18 @@ def show_one_dimensional_trajectory_to_strata(e, sigma_dist=None,
         ax_s = divider.append_axes("right", 0.5, pad=0.1, sharey=ax)
         ax_s.yaxis.tick_right()
         ax_s.xaxis.set_visible(False)
-        __x, __y = np.meshgrid(np.array([0, 1]), z)
+        __x, __y = np.meshgrid(np.array([0, 1]), z_disp)
         _colmap = plt.cm.get_cmap('viridis', e.shape[0])
         ax_s.pcolormesh(__x, __y, cp,
                         cmap=_colmap, vmin=0, vmax=e.shape[0],
-                        shading='auto')
+                        rasterized=True, shading='flat')
         ax_s.hlines(e[p], 0, 1, linestyles='dashed', colors='gray')
         _cstr = [str(int(cc)) if np.isfinite(cc) else 'nan' for cc in c.flatten()]
         ax_s.set_xlim(0, 1)
         if label_strata:
-            for i, __cstr in enumerate(_cstr):
-                ax_s.text(0.3, z[i], str(__cstr), fontsize=8)
+            for i, __cstr in enumerate(_cstr[:-1]):
+                ax_s.text(0.5, z[i]+((z[i+1]-z[i])/2), str(__cstr),
+                          fontsize=8, ha='center', va='center')
 
     # adjust and add legend
     if np.any(e < 0):

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -493,7 +493,7 @@ class BaseSection(abc.ABC):
             ci = ax.pcolormesh(_X, _Y, _data, cmap=_varinfo.cmap,
                                norm=_varinfo.norm,
                                vmin=_varinfo.vmin, vmax=_varinfo.vmax,
-                               rasterized=True, shading='auto')
+                               shading='flat')
         elif style in ['line', 'lines']:
             _data, _segments = plot.get_display_lines(SectionVariableInstance,
                                                       data=data)

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -493,7 +493,7 @@ class BaseSection(abc.ABC):
             ci = ax.pcolormesh(_X, _Y, _data, cmap=_varinfo.cmap,
                                norm=_varinfo.norm,
                                vmin=_varinfo.vmin, vmax=_varinfo.vmax,
-                               shading='flat')
+                               shading='flat', rasterized=True)
         elif style in ['line', 'lines']:
             _data, _segments = plot.get_display_lines(SectionVariableInstance,
                                                       data=data)

--- a/deltametrics/strat.py
+++ b/deltametrics/strat.py
@@ -591,7 +591,7 @@ def _compute_preservation_to_cube(strata, z):
         with rows in `strat_coords`.
     """
     # preallocate boxy arrays and helpers
-    plate = np.atleast_1d(np.zeros(strata.shape[1:], dtype=np.int8))
+    plate = np.atleast_1d(np.zeros(strata.shape[1:], dtype=int))
     strat_coords, data_coords = [], []  # preallocate sparse idx lists
     _zero = np.array([0])
 
@@ -600,7 +600,7 @@ def _compute_preservation_to_cube(strata, z):
     for k in np.arange(len(z) - 1, -1, -1):  # for every z, from the top
         e = z[k]  # which elevation for this iteration
         whr = e < seek_elev  # where elev is below strat surface
-        t = np.maximum(_zero, (np.argmin(strata[:, ...] <= e, axis=0) - 1))
+        t = np.maximum(_zero, (np.argmin(strata[:, ...] <= e, axis=0)))
         plate[whr] = int(1)  # track locations in the plate
 
         xy = plate.nonzero()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -408,7 +408,10 @@ class TestGetDisplayArrays:
     def test_dsv_nostrat_get_display_arrays_spacetime(self):
         _data, _X, _Y = plot.get_display_arrays(self.dsv_nostrat,
                                                 data='spacetime')
-        assert (_data.shape == _X.shape) and (_data.shape == _Y.shape)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
         assert np.all(_data == self.dsv_nostrat)
 
     def test_dsv_nostrat_get_display_arrays_preserved(self):
@@ -424,13 +427,19 @@ class TestGetDisplayArrays:
     def test_dsv_get_display_arrays_spacetime(self):
         _data, _X, _Y = plot.get_display_arrays(self.dsv,
                                                 data='spacetime')
-        assert (_data.shape == _X.shape) and (_data.shape == _Y.shape)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
         assert np.all(_data == self.dsv)
 
     def test_dsv_get_display_arrays_preserved(self):
         _data, _X, _Y = plot.get_display_arrays(self.dsv,
                                                 data='preserved')
-        assert (_data.shape == _X.shape) and (_data.shape == _Y.shape)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
         assert np.any(np.isnan(_data))  # check that some are False
 
     def test_dsv_get_display_arrays_stratigraphy(self):
@@ -461,7 +470,10 @@ class TestGetDisplayArrays:
     def test_ssv_get_display_arrays_stratigraphy(self):
         _data, _X, _Y = plot.get_display_arrays(
             self.ssv, data='stratigraphy')
-        assert (_data.shape == _X.shape) and (_data.shape == _Y.shape)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
+        assert (_data.shape[0] == _X.shape[0] - 1)
+        assert (_data.shape[1] == _Y.shape[1] - 1)
 
     def test_ssv_get_display_arrays_badstring(self):
         with pytest.raises(ValueError, match=r'Bad data *.'):

--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -311,7 +311,7 @@ class TestOneDimStratigraphyExamples:
         assert s[-1] == e[-1]
         assert s[-1] == e[-1]
         assert np.all(np.isnan(c[2:]))  # from z>=1 to z==3
-        assert np.all(c[:2] == 0)
+        assert np.all(c[:2] == 1)
         assert lst == 1
 
     def test_onedim_traj_drop_at_end_to_zero(self):
@@ -335,7 +335,7 @@ class TestOneDimStratigraphyExamples:
         assert z[-1] == 7
         assert s[-1] == 6
         assert np.all(p.nonzero()[0] == (2, 3, 7, 10))
-        assert c[0] == 1
+        assert c[0] == 2
 
     def test_onedim_traj_upsanddowns_negatives(self):
         # e = np.array([0, 0, -1, -4, -2, 3, 3.5, 3, 3, 4, 4])


### PR DESCRIPTION
tweaks to stratigraphy calculation and display.

This PR implements some fixes to the way data is attributed to voxels in stratigraphy, and fixes bugs with the display of the sections with `pcolormesh`.

| before | after |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/8801322/189446537-913c0d9c-1432-444e-a3f2-91f90d33e93b.png) | ![image](https://user-images.githubusercontent.com/8801322/196753468-c1a72b0b-ba89-43bd-a8f2-03d681f12052.png) |

**This change will impact the entire stratigraphic volume calculated**, so it is a breaking change. But, the impact is mostly seen where very rapid aggradation occurs (e.g., the prograding delta front). Because we always throw away this portion of the volume for calculations, I don't think this change is too important.

TODO
- [x] fix the display of mesh arrays to an acceptable condition. Currently `eta` is broken, due to filling with zeros, which works for other fields (by chance) but not eta.
