### PR TITLE
Implement array initiation for masks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ['3.8', '3.9', '3.10']
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -278,27 +278,9 @@ class ThresholdValueMask(BaseMask, abc.ABC):
     This mask implements a binarization of a raster based on a threshold
     values.
     """
-    @staticmethod
-    def from_array(_arr):
-        """Create an `ElevationMask` from an array.
-
-        .. note::
-
-            Instantiation with `from_array` will attempt to any data type
-            (`dtype`) to boolean. This may have unexpected results. Convert
-            your array to a boolean before using `from_array` to ensure the
-            mask is created correctly.
-
-        Parameters
-        ----------
-        _arr : :obj:`ndarray`
-            The array with values to set as the mask. Can be any `dtype` but
-            will be coerced to `boolean`.
-        """
-        # set directly
-        raise NotImplementedError
-
     def __init__(self, *args, threshold, cube_key=None, **kwargs):
+
+        # super().__init__('threshold', *args, **kwargs)
 
         self._threshold = threshold
 
@@ -356,6 +338,32 @@ class ElevationMask(ThresholdValueMask):
         plt.show()
     """
 
+    @staticmethod
+    def from_array(_arr):
+        """Create an `ElevationMask` from an array.
+
+        .. note::
+
+            Instantiation with `from_array` will attempt to any data type
+            (`dtype`) to boolean. This may have unexpected results. Convert
+            your array to a boolean before using `from_array` to ensure the
+            mask is created correctly.
+
+        Parameters
+        ----------
+        _arr : :obj:`ndarray`
+            The array with values to set as the mask. Can be any `dtype` but
+            will be coerced to `boolean`.
+        """
+        # set directly
+        _EM = ElevationMask(allow_empty=True, elevation_threshold=None)
+        _EM._set_shape_mask(_arr)
+        _EM._input_elevation_threshold = None
+        _EM._elevation_offset = None
+        _EM._input_flag = None
+        _EM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _EM
+
     def __init__(self, *args, elevation_threshold, elevation_offset=0,
                  cube_key='eta', **kwargs):
         """Initialize the ElevationMask.
@@ -363,10 +371,12 @@ class ElevationMask(ThresholdValueMask):
         .. note:: Needs docstring!
 
         """
-
         self._input_elevation_threshold = elevation_threshold
         self._elevation_offset = elevation_offset
-        _threshold = elevation_threshold + elevation_offset
+        if elevation_threshold is None:
+            _threshold = None
+        else:
+            _threshold = elevation_threshold + elevation_offset
 
         BaseMask.__init__(self, 'elevation', *args, **kwargs)
         ThresholdValueMask.__init__(self, *args, threshold=_threshold,
@@ -425,6 +435,30 @@ class FlowMask(ThresholdValueMask):
         fdmsk.show(ax=ax[1])
         plt.show()
     """
+
+    @staticmethod
+    def from_array(_arr):
+        """Create an `ElevationMask` from an array.
+
+        .. note::
+
+            Instantiation with `from_array` will attempt to any data type
+            (`dtype`) to boolean. This may have unexpected results. Convert
+            your array to a boolean before using `from_array` to ensure the
+            mask is created correctly.
+
+        Parameters
+        ----------
+        _arr : :obj:`ndarray`
+            The array with values to set as the mask. Can be any `dtype` but
+            will be coerced to `boolean`.
+        """
+        # set directly
+        _FM = FlowMask(allow_empty=True, flow_threshold=None)
+        _FM._set_shape_mask(_arr)
+        _FM._input_flag = None
+        _FM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _FM
 
     def __init__(self, *args, flow_threshold, cube_key='velocity', **kwargs):
         """Initialize the FlowMask.
@@ -590,7 +624,7 @@ class ChannelMask(BaseMask):
         _CM = ChannelMask(allow_empty=True)
         _CM._set_shape_mask(_arr)
         _CM._input_flag = None
-        _CM._mask = _arr.astype(bool)  # set the array as mask
+        _CM._mask[:] = _arr.astype(bool)  # set the array as mask
         return _CM
 
     def __init__(self, *args, is_mask=None, **kwargs):
@@ -813,7 +847,11 @@ class WetMask(BaseMask):
             will be coerced to `boolean`.
         """
         # set directly
-        raise NotImplementedError
+        _WM = WetMask(allow_empty=True)
+        _WM._set_shape_mask(_arr)
+        _WM._input_flag = None
+        _WM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _WM
 
     def __init__(self, *args, **kwargs):
         """Initialize the WetMask.
@@ -1037,7 +1075,11 @@ class LandMask(BaseMask):
             will be coerced to `boolean`.
         """
         # set directly
-        raise NotImplementedError
+        _LM = LandMask(allow_empty=True)
+        _LM._set_shape_mask(_arr)
+        _LM._input_flag = None
+        _LM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _LM
 
     def __init__(self, *args, contour_threshold=75,
                  method='OAM', **kwargs):
@@ -1252,7 +1294,7 @@ class ShorelineMask(BaseMask):
         _SM._set_shape_mask(_arr)
         _SM._contour_threshold = None
         _SM._input_flag = None
-        _SM._mask = _arr.astype(bool)  # set the array as mask
+        _SM._mask[:] = _arr.astype(bool)  # set the array as mask
         return _SM
 
     def __init__(self, *args, contour_threshold=75, method='OAM', **kwargs):
@@ -1619,7 +1661,11 @@ class EdgeMask(BaseMask):
             The array with values to set as the mask. Can be any `dtype` but
             will be coerced to `boolean`.
         """
-        raise NotImplementedError
+        _EM = EdgeMask(allow_empty=True)
+        _EM._set_shape_mask(_arr)
+        _EM._input_flag = None
+        _EM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _EM
 
     def __init__(self, *args, **kwargs):
         """Initialize the EdgeMask.
@@ -1856,7 +1902,11 @@ class CenterlineMask(BaseMask):
             will be coerced to `boolean`.
         """
         # set directly
-        raise NotImplementedError
+        _CM = CenterlineMask(allow_empty=True)
+        _CM._set_shape_mask(_arr)
+        _CM._input_flag = None
+        _CM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _CM
 
     def __init__(self, *args, method='skeletonize', **kwargs):
         """Initialize the CenterlineMask.
@@ -2075,7 +2125,11 @@ class GeometricMask(BaseMask):
             will be coerced to `boolean`.
         """
         # set directly
-        raise NotImplementedError
+        _GM = GeometricMask(allow_empty=True)
+        _GM._set_shape_mask(_arr)
+        _GM._input_flag = None
+        _GM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _GM
 
     def __init__(self, *args, origin=None, **kwargs):
         """Initialize the GeometricMask.
@@ -2413,7 +2467,11 @@ class DepositMask(BaseMask):
             will be coerced to `boolean`.
         """
         # set directly
-        raise NotImplementedError
+        _DM = DepositMask(allow_empty=True)
+        _DM._set_shape_mask(_arr)
+        _DM._input_flag = None
+        _DM._mask[:] = _arr.astype(bool)  # set the array as mask
+        return _DM
 
     def __init__(self, *args, background_value=0,
                  elevation_tolerance=0.1, **kwargs):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -510,14 +510,28 @@ class TestElevationMask:
         assert np.all(elevationmask._mask[:_row, :third] == 1)
         assert np.all(elevationmask._mask[_row:, :] == 0)
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
-        elevationmask = mask.ElevationMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        elevmask = mask.ElevationMask.from_array(_arr)
         # make assertions
-        assert elevationmask._input_flag == 'elevation'
+        assert elevmask.mask_type == 'elevation'
+        assert elevmask._input_flag is None
+        assert np.all(elevmask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(bool)
+
+        assert _arr2.dtype == float
+
+        elevmask2 = mask.ElevationMask.from_array(_arr2)
+        # make assertions
+        assert elevmask2.mask_type == 'elevation'
+        assert elevmask2._input_flag is None
+        assert np.all(elevmask2._mask == _arr2_bool)
 
 
 class TestFlowMask:
@@ -681,14 +695,28 @@ class TestFlowMask:
         # assert - expect doesnt care about land
         assert flowmask.mask_type == 'flow'
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
-        flowmask = mask.FlowMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        flowmask = mask.FlowMask.from_array(_arr)
         # make assertions
-        assert flowmask._input_flag == 'flow'
+        assert flowmask.mask_type == 'flow'
+        assert flowmask._input_flag is None
+        assert np.all(flowmask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(bool)
+
+        assert _arr2.dtype == float
+
+        flowmask2 = mask.FlowMask.from_array(_arr2)
+        # make assertions
+        assert flowmask2.mask_type == 'flow'
+        assert flowmask2._input_flag is None
+        assert np.all(flowmask2._mask == _arr2_bool)
 
 
 class TestLandMask:
@@ -865,14 +893,27 @@ class TestLandMask:
                           elevation_threshold=0.0,
                           method='invalid')
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
-        # define the mask
-        landmask = mask.LandMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        landmask = mask.LandMask.from_array(_arr)
         # make assertions
-        assert landmask._input_flag == 'land'
+        assert landmask.mask_type == 'land'
+        assert landmask._input_flag is None
+        assert np.all(landmask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(bool)
+
+        assert _arr2.dtype == float
+
+        landmask2 = mask.LandMask.from_array(_arr2)
+        # make assertions
+        assert landmask2.mask_type == 'land'
+        assert landmask2._input_flag is None
+        assert np.all(landmask2._mask == _arr2_bool)
 
 
 class TestWetMask:
@@ -1005,14 +1046,29 @@ class TestWetMask:
         assert np.all(wetmask_0._mask == mfem._mask)
         assert np.sum(wetmask_0.integer_mask) == np.sum(mfem.integer_mask)
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
-        wetmask = mask.WetMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        wetmask = mask.WetMask.from_array(_arr)
         # make assertions
-        assert wetmask._input_flag == 'land'
+        assert wetmask.mask_type == 'wet'
+        assert wetmask._input_flag is None
+        assert np.all(wetmask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(bool)
+
+        assert _arr2.dtype == float
+        assert _arr2_bool.dtype == bool
+
+        wetmask2 = mask.WetMask.from_array(_arr2)
+        # make assertions
+        assert wetmask2.mask_type == 'wet'
+        assert wetmask2._input_flag is None
+        assert np.all(wetmask2._mask == _arr2_bool)
 
 
 class TestChannelMask:
@@ -1221,8 +1277,6 @@ class TestChannelMask:
         with pytest.raises(TypeError):
             mask.ChannelMask.from_mask(wetmask, landmask)
 
-    # @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-    #                    reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
@@ -1371,14 +1425,28 @@ class TestEdgeMask:
         assert np.all(edgemask_comp._mask == mfem2._mask)
         assert np.all(mfem._mask == mfem2._mask)
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
-        channelmask = mask.EdgeMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        edgemask = mask.EdgeMask.from_array(_arr)
         # make assertions
-        assert channelmask._input_flag == 'channel'
+        assert edgemask.mask_type == 'edge'
+        assert edgemask._input_flag is None
+        assert np.all(edgemask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(bool)
+
+        assert _arr2.dtype == float
+
+        edgemask2 = mask.EdgeMask.from_array(_arr2)
+        # make assertions
+        assert edgemask2.mask_type == 'edge'
+        assert edgemask2._input_flag is None
+        assert np.all(edgemask2._mask == _arr2_bool)
 
 
 class TestCenterlineMask:
@@ -1556,14 +1624,28 @@ class TestCenterlineMask:
         assert np.all(centerlinemask_comp._mask == mfem2._mask)
         assert np.all(mfem._mask == mfem2._mask)
 
-    @pytest.mark.xfail(raises=NotImplementedError, strict=True,
-                       reason='Have not implemented pathway.')
     def test_static_from_array(self):
         """Test that instantiation works for an array."""
         # define the mask
-        channelmask = mask.CenterlineMask.from_array(np.ones((100, 200)))
+        _arr = np.ones((100, 200))
+        _arr[50:55, :] = 0
+
+        centerlinemask = mask.CenterlineMask.from_array(_arr)
         # make assertions
-        assert channelmask._input_flag == 'channel'
+        assert centerlinemask.mask_type == 'centerline'
+        assert centerlinemask._input_flag is None
+        assert np.all(centerlinemask._mask == _arr)
+
+        _arr2 = np.random.uniform(size=(100, 200))
+        _arr2_bool = _arr2.astype(bool)
+
+        assert _arr2.dtype == float
+
+        centerlinemask2 = mask.CenterlineMask.from_array(_arr2)
+        # make assertions
+        assert centerlinemask2.mask_type == 'centerline'
+        assert centerlinemask2._input_flag is None
+        assert np.all(centerlinemask2._mask == _arr2_bool)
 
     @pytest.mark.xfail(raises=ImportError,
                        reason='rivamap is not installed.')


### PR DESCRIPTION
The `mask.XxxxxMask.from_array()` pathways have existed for a while, but were not fully integrated. This PR completes that integration for the masks, and updates/adds tests.