### PR TITLE
Change from imgmath to mathjax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -38,7 +38,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.napoleon',
               'sphinx.ext.graphviz',
-              'sphinx.ext.imgmath',
+              'sphinx.ext.mathjax',
               'sphinx.ext.githubpages',
               'matplotlib.sphinxext.plot_directive',
               'sphinx.ext.todo']


### PR DESCRIPTION
Following changes in pyDeltaRCM, change to use mathjax