### PR TITLE
codecov-job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,26 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=deltametrics/ --cov-report=xml
+        
+  codecov:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-cov coveralls
+        pip install -r requirements.txt
+    - name: Install DeltaMetrics
+      run: |
+        pip install -e .
+    - name: Test with pytest
+      run: |
+        pytest --cov=deltametrics/ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
@@ -44,6 +64,7 @@ jobs:
         env_vars: OS,PYTHON
         name: codecov-umbrella
         fail_ci_if_error: true
+    
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,26 +36,6 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov=deltametrics/ --cov-report=xml
-        
-  codecov:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov coveralls
-        pip install -r requirements.txt
-    - name: Install DeltaMetrics
-      run: |
-        pip install -e .
-    - name: Test with pytest
-      run: |
-        pytest --cov=deltametrics/ --cov-report=xml
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
       with:
@@ -63,8 +43,7 @@ jobs:
         file: ./coverage.xml
         env_vars: OS,PYTHON
         name: codecov-umbrella
-        fail_ci_if_error: true
-    
+        fail_ci_if_error: false
 
   docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
only push coverage results to codecov for one job, not all the different versions

right now we get a bunch of failing tests because coverage results couldn't be pushed to codecov, this seems unnecessary, we can just have one job send results to codecoverage, the others can just install and run the tests.