### PR TITLE
compute_land_area

### DIFF
--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1093,6 +1093,11 @@ def compute_land_area(land_mask):
     is the area of each cell where :math:`A_{ij} =dx^2` if the mask is
     `True`, otherwise :math:`A_{ij} = 0`.
 
+    Will return area with the same base units as the spatial coordinates of
+    input array (i.e., for a :obj:`Mask` or `xarray.DataArray`). In the case
+    of a `numpy` array without coordinates, a unit dimension is assumed for
+    each cell.
+
     .. note::
 
         In implementation, this is a simple 1-liner summation over the mask.

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1072,13 +1072,86 @@ class MorphologicalPlanform(SpecialtyPlanform):
 
     @property
     def below_mask(self):
-        """Mask for below sea level pixels.
-        """
+        """Mask for below sea level pixels."""
         return self._below_mask
 
     @property
     def data(self):
         return self._mean_image
+
+
+def compute_land_area(land_mask):
+    """Compute land (delta) area.
+
+    Computes the land area for a LandMask as:
+
+    .. math::
+
+        \\sum_{i=1}^L \\sum_{j=1}^W A_{ij}
+
+    where :math:`L` and :math:`W` are the mask dimensions, and :math:`A_{ij}`
+    is the area of each cell where :math:`A_{ij} =dx^2` if the mask is
+    `True`, otherwise :math:`A_{ij} = 0`.
+
+    .. note::
+
+        In implementation, this is a simple 1-liner summation over the mask.
+        It is implemented as a function here for convenience and consistency
+        in the api.
+
+        .. code::
+
+            land_area = np.sum(land_mask.integer_mask) * dx * dx
+
+    Parameters
+    ----------
+    land_mask : :obj:`~deltametrics.mask.LandMask`, :obj:`ndarray`
+        Land mask. Can be a :obj:`~deltametrics.mask.LandMask` object,
+        or a binarized array.
+
+    Returns
+    -------
+    land_area : :obj:`float`
+        Land area, computed as described above.
+
+    Examples
+    --------
+    .. plot::
+        :include-source:
+        :context: reset
+
+        golf = dm.sample_data.golf()
+
+        lm = dm.mask.LandMask(
+            golf['eta'][-1, :, :],
+            elevation_threshold=golf.meta['H_SL'][-1],
+            elevation_offset=-0.5)
+
+        lm.trim_mask(length=golf.meta['L0'].data+1)
+
+        land_area = dm.plan.compute_land_area(lm)
+
+        fig, ax = plt.subplots()
+        lm.show(ax=ax, ticks=True)
+        ax.set_title(f'Land area is {land_area/1e6:.1f} km$^2$')
+        plt.show()
+
+    """
+    # extract data from masks
+    if isinstance(land_mask, mask.LandMask):
+        land_mask = land_mask.mask
+        _lm = land_mask.values
+        _dx = float(land_mask[land_mask.dims[0]][1] - land_mask[land_mask.dims[0]][0])
+    elif isinstance(land_mask, xr.core.dataarray.DataArray):
+        _lm = land_mask.values
+        _dx = float(land_mask[land_mask.dims[0]][1] - land_mask[land_mask.dims[0]][0])
+    elif isinstance(land_mask, np.ndarray):
+        _lm = land_mask
+        _dx = 1
+    else:
+        raise TypeError("Invalid type {0}".format(type(land_mask)))
+
+    return np.sum(_lm) * _dx * _dx
 
 
 def compute_shoreline_roughness(shore_mask, land_mask, **kwargs):

--- a/docs/source/guides/examples/computations/shoreline_roughness_perfect_direct.rst
+++ b/docs/source/guides/examples/computations/shoreline_roughness_perfect_direct.rst
@@ -64,16 +64,16 @@ A perfect half-circle rasterized
         np.linspace(0, dx*hcirc.shape[0], num=hcirc.shape[0]))
     center = (0, 5000)
 
-    dists = (dx * np.sqrt((y - center[0])**2 +
-                          (x - center[1])**2))
+    dists = (np.sqrt((y - center[0])**2 +
+                     (x - center[1])**2))
     dists_flat = dists.flatten()
 
     # apply the landscape change inside the domain
-    in_idx = np.where(dists_flat <= 12000)[0]
+    in_idx = np.where(dists_flat <= 3000)[0]
     hcirc.flat[in_idx] = True
 
     fig, ax = plt.subplots()
-    ax.imshow(hcirc)
+    ax.imshow(hcirc, extent=[x.min(), x.max(), y.max(), y.min()])
     plt.show()
 
 

--- a/docs/source/guides/examples/computations/shoreline_roughness_perfect_direct.rst
+++ b/docs/source/guides/examples/computations/shoreline_roughness_perfect_direct.rst
@@ -25,11 +25,11 @@ The area of a half circle is given:
     A = (1/2)~\pi r^2
 
 
-The circumference of a circle is given:
+The circumference of a half circle is given:
 
 .. math::
 
-    P = \\pi r
+    P = \pi r
 
 Establish values for the radius :math:`r`, and evaluate the shoreline roughness metric directly:
 

--- a/docs/source/reference/plan/index.rst
+++ b/docs/source/reference/plan/index.rst
@@ -39,6 +39,7 @@ Functions
 .. autosummary::
     :toctree: ../../_autosummary
 
+    compute_land_area
     compute_shoreline_roughness
     compute_shoreline_length
     compute_shoreline_distance


### PR DESCRIPTION
Adds a very basic planform computation for land area from a LandMask or LandMask-like array.

```
land_area = dm.plan.compute_land_area(lm)
```

![image](https://user-images.githubusercontent.com/8801322/216717377-c824ff7b-5039-49bf-9863-f051bac543f2.png)
