### PR TITLE
Io testing

### DIFF
--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -52,7 +52,7 @@ class VariableInfo(object):
     .. doctest::
 
         >>> veg3 = VariableInfo('vegetation_density',
-        ...                     cmap=mpl.colormaps['Greens'].resampled(3))
+        ...                     cmap=matplotlib.colormaps['Greens'].resampled(3))
         >>> veg3.cmap.N
         3
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,7 @@ doctest_global_setup = '''
 import deltametrics as dm
 import numpy as np
 from matplotlib import pyplot as plt
+import matplotlib
 '''
 
 # empty string disables testing all code in any docstring

--- a/docs/source/guides/10min.rst
+++ b/docs/source/guides/10min.rst
@@ -67,11 +67,12 @@ The underlying xarray object can be directly accessed by using a ``.data`` attri
 .. doctest::
 
     >>> np.mean( golfcube['eta'][1:,43,123] - golfcube['eta'][:-1,43,123] )
-    <xarray.DataArray 'eta' ()>
+    <xarray.DataArray 'eta' ()> Size: 4B
     array(0., dtype=float32)
     Coordinates:
-        x        float32 2.15e+03
-        y        float32 6.15e+03
+        x        float32 4B 2.15e+03
+        y        float32 4B 6.15e+03
+
 
 
 

--- a/docs/source/guides/subject_guides/section.rst
+++ b/docs/source/guides/subject_guides/section.rst
@@ -21,7 +21,7 @@ The data that make up the section can view the section as a `spacetime` section 
     >>> rcm8cube = dm.sample_data.golf()
     >>> strike = dm.section.StrikeSection(rcm8cube, distance_idx=10)
     >>> strike['velocity']
-    <xarray.DataArray 'velocity' (time: 101, s: 200)>
+    <xarray.DataArray 'velocity' (time: 101, s: 200)> Size: 81kB
     array([[0.2   , 0.2   , 0.2   , ..., 0.2   , 0.2   , 0.2   ],
            [0.    , 0.    , 0.    , ..., 0.    , 0.    , 0.    ],
            [0.    , 0.0025, 0.    , ..., 0.    , 0.    , 0.    ],
@@ -31,12 +31,13 @@ The data that make up the section can view the section as a `spacetime` section 
            [0.    , 0.    , 0.    , ..., 0.0025, 0.    , 0.    ]],
           dtype=float32)
     Coordinates:
-      * s        (s) float64 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
-      * time     (time) float32 0.0 5e+05 1e+06 1.5e+06 ... 4.9e+07 4.95e+07 5e+07
+      * s        (s) float64 2kB 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
+      * time     (time) float32 404B 0.0 5e+05 1e+06 ... 4.9e+07 4.95e+07 5e+07
     Attributes:
         slicetype:           data_section
         knows_stratigraphy:  False
         knows_spacetime:     True
+
 
 
 If a `DataCube` has preservation information (i.e., if the :meth:`~deltametrics.cube.DataCube.stratigraphy_from()` method has been called), then the `xarray` object that is returned has this information too.
@@ -46,7 +47,7 @@ The same `spacetime` data can be requested in the "preserved" form, where non-pr
 
     >>> rcm8cube.stratigraphy_from('eta')
     >>> strike['velocity'].strat.as_preserved()
-    <xarray.DataArray 'velocity' (time: 101, s: 200)>
+    <xarray.DataArray 'velocity' (time: 101, s: 200)> Size: 81kB
     array([[0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],
            [nan, nan, nan, ..., nan, nan, nan],
            [nan, nan, nan, ..., nan, nan, nan],
@@ -55,8 +56,8 @@ The same `spacetime` data can be requested in the "preserved" form, where non-pr
            [nan, nan, nan, ..., nan, nan, nan],
            [nan, nan, nan, ..., nan, nan, nan]], dtype=float32)
     Coordinates:
-      * s        (s) float64 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
-      * time     (time) float32 0.0 5e+05 1e+06 1.5e+06 ... 4.9e+07 4.95e+07 5e+07
+      * s        (s) float64 2kB 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
+      * time     (time) float32 404B 0.0 5e+05 1e+06 ... 4.9e+07 4.95e+07 5e+07
     Attributes:
         slicetype:           data_section
         knows_stratigraphy:  True

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -150,7 +150,7 @@ The data returned from the planform are an `xarray` `DataArray`, so you can cont
     >>> final.shape
     (100, 200)
     >>> final['eta']
-    <xarray.DataArray 'eta' (x: 100, y: 200)>
+    <xarray.DataArray 'eta' (x: 100, y: 200)> Size: 80kB
     array([[ 0.015 ,  0.015 ,  0.015 , ...,  0.015 ,  0.015 ,  0.015 ],
            [ 0.0075,  0.0075,  0.0075, ...,  0.0075,  0.0075,  0.0075],
            [ 0.    ,  0.    ,  0.    , ...,  0.    ,  0.    ,  0.    ],
@@ -160,9 +160,9 @@ The data returned from the planform are an `xarray` `DataArray`, so you can cont
            [-2.    , -2.    , -2.    , ..., -2.    , -2.    , -2.    ]],
           dtype=float32)
     Coordinates:
-        time     float32 5e+07
-      * x        (x) float32 0.0 50.0 100.0 150.0 ... 4.85e+03 4.9e+03 4.95e+03
-      * y        (y) float32 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
+        time     float32 4B 5e+07
+      * x        (x) float32 400B 0.0 50.0 100.0 150.0 ... 4.85e+03 4.9e+03 4.95e+03
+      * y        (y) float32 800B 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
     Attributes:
         slicetype:           data_planform
         knows_stratigraphy:  False
@@ -257,7 +257,7 @@ are sliced themselves, similarly to the cube.
 
     >>> golfcube.register_section('demo', dm.section.StrikeSection(distance_idx=10))
     >>> golfcube.sections['demo']['velocity']
-    <xarray.DataArray 'velocity' (time: 101, s: 200)>
+    <xarray.DataArray 'velocity' (time: 101, s: 200)> Size: 81kB
     array([[0.2   , 0.2   , 0.2   , ..., 0.2   , 0.2   , 0.2   ],
            [0.    , 0.    , 0.    , ..., 0.    , 0.    , 0.    ],
            [0.    , 0.0025, 0.    , ..., 0.    , 0.    , 0.    ],
@@ -267,8 +267,8 @@ are sliced themselves, similarly to the cube.
            [0.    , 0.    , 0.    , ..., 0.0025, 0.    , 0.    ]],
           dtype=float32)
     Coordinates:
-      * s        (s) float64 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
-      * time     (time) float32 0.0 5e+05 1e+06 1.5e+06 ... 4.9e+07 4.95e+07 5e+07
+      * s        (s) float64 2kB 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
+      * time     (time) float32 404B 0.0 5e+05 1e+06 ... 4.9e+07 4.95e+07 5e+07
     Attributes:
         slicetype:           data_section
         knows_stratigraphy:  False
@@ -321,7 +321,7 @@ Now, the ``DataCube`` has knowledge of stratigraphy, which we can further use to
 .. doctest::
 
     >>> golfcube.sections['demo']['velocity'].strat.as_preserved()
-    <xarray.DataArray 'velocity' (time: 101, s: 200)>
+    <xarray.DataArray 'velocity' (time: 101, s: 200)> Size: 81kB
     array([[0.2, 0.2, 0.2, ..., 0.2, 0.2, 0.2],
            [nan, nan, nan, ..., nan, nan, nan],
            [nan, nan, nan, ..., nan, nan, nan],
@@ -330,12 +330,13 @@ Now, the ``DataCube`` has knowledge of stratigraphy, which we can further use to
            [nan, nan, nan, ..., nan, nan, nan],
            [nan, nan, nan, ..., nan, nan, nan]], dtype=float32)
     Coordinates:
-      * s        (s) float64 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
-      * time     (time) float32 0.0 5e+05 1e+06 1.5e+06 ... 4.9e+07 4.95e+07 5e+07
+      * s        (s) float64 2kB 0.0 50.0 100.0 150.0 ... 9.85e+03 9.9e+03 9.95e+03
+      * time     (time) float32 404B 0.0 5e+05 1e+06 ... 4.9e+07 4.95e+07 5e+07
     Attributes:
         slicetype:           data_section
         knows_stratigraphy:  True
         knows_spacetime:     True
+
 
 
 .. doctest::

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -446,13 +446,13 @@ class TestLegacyPyDeltaRCMCube:
         assert type(rcm8cube.varset) is plot.VariableSet
 
         # check that two warnings were raised
-        assert re.match(
+        assert any(re.match(
             r'Coordinates for "time", .*',
-            record[0].message.args[0]
-            )
-        assert re.match(
+            _warning.message.args[0]) for _warning in record)
+
+        assert any(re.match(
             r'No associated metadata .*',
-            record[1].message.args[0])
+            _warning.message.args[0]) for _warning in record)
 
     def test_warning_netcdf_no_metadata(self):
         with pytest.warns(UserWarning, match=r'No associated metadata'):

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -20,7 +20,6 @@ hdf_path = _get_landsat_path()
 
 
 class TestDataCubeNoStratigraphy:
-
     # create a fixed cube for variable existing, type checks
     fixeddatacube = cube.DataCube(golf_path)
 
@@ -29,7 +28,7 @@ class TestDataCubeNoStratigraphy:
     def test_init_cube_from_path_rcm8(self):
         golf = cube.DataCube(golf_path)
         assert golf._data_path == golf_path
-        assert golf.dataio.io_type == 'netcdf'
+        assert golf.dataio.io_type == "netcdf"
         assert golf._planform_set == {}
         assert golf._section_set == {}
         assert type(golf.varset) is plot.VariableSet
@@ -40,11 +39,11 @@ class TestDataCubeNoStratigraphy:
 
     def test_error_init_bad_path(self):
         with pytest.raises(FileNotFoundError):
-            _ = cube.DataCube('./nonexistent/path.nc')
+            _ = cube.DataCube("./nonexistent/path.nc")
 
     def test_error_init_bad_extension(self):
         with pytest.raises(ValueError):
-            _ = cube.DataCube('./nonexistent/path.doc')
+            _ = cube.DataCube("./nonexistent/path.doc")
 
     def test_error_init_bad_type(self):
         with pytest.raises(TypeError):
@@ -53,12 +52,12 @@ class TestDataCubeNoStratigraphy:
     def test_stratigraphy_from_eta(self):
         golf0 = cube.DataCube(golf_path)
         golf1 = cube.DataCube(golf_path)
-        golf0.stratigraphy_from('eta')
+        golf0.stratigraphy_from("eta")
         assert golf0._knows_stratigraphy is True
         assert golf1._knows_stratigraphy is False
 
     def test_init_cube_stratigraphy_argument(self):
-        golf = cube.DataCube(golf_path, stratigraphy_from='eta')
+        golf = cube.DataCube(golf_path, stratigraphy_from="eta")
         assert golf._knows_stratigraphy is True
 
     def test_stratigraphy_from_default_noargument(self):
@@ -84,7 +83,7 @@ class TestDataCubeNoStratigraphy:
 
     def test_slice_op(self):
         golf = cube.DataCube(golf_path)
-        slc = golf['eta']
+        slc = golf["eta"]
         assert type(slc) is xr.core.dataarray.DataArray
         assert slc.ndim == 3
         assert type(slc.values) is np.ndarray
@@ -92,67 +91,62 @@ class TestDataCubeNoStratigraphy:
     def test_slice_op_invalid_name(self):
         golf = cube.DataCube(golf_path)
         with pytest.raises(AttributeError):
-            _ = golf['nonexistentattribute']
+            _ = golf["nonexistentattribute"]
 
     def test_register_section(self):
         golf = cube.DataCube(golf_path)
-        golf.stratigraphy_from('eta', dz=0.1)
-        golf.register_section(
-            'testsection', section.StrikeSection(distance_idx=10))
+        golf.stratigraphy_from("eta", dz=0.1)
+        golf.register_section("testsection", section.StrikeSection(distance_idx=10))
         assert golf.sections is golf.section_set
         assert len(golf.sections.keys()) == 1
-        assert 'testsection' in golf.sections.keys()
-        with pytest.raises(TypeError, match=r'`SectionInstance` .*'):
-            golf.register_section('fail1', 'astring')
-        with pytest.raises(TypeError, match=r'`SectionInstance` .*'):
-            golf.register_section('fail2', 22)
-        with pytest.raises(TypeError, match=r'`name` .*'):
+        assert "testsection" in golf.sections.keys()
+        with pytest.raises(TypeError, match=r"`SectionInstance` .*"):
+            golf.register_section("fail1", "astring")
+        with pytest.raises(TypeError, match=r"`SectionInstance` .*"):
+            golf.register_section("fail2", 22)
+        with pytest.raises(TypeError, match=r"`name` .*"):
             golf.register_section(22, section.StrikeSection(distance_idx=10))
 
     def test_sections_slice_op(self):
         golf = cube.DataCube(golf_path)
-        golf.stratigraphy_from('eta', dz=0.1)
-        golf.register_section(
-            'testsection', section.StrikeSection(distance_idx=10))
-        assert 'testsection' in golf.sections.keys()
-        slc = golf.sections['testsection']
+        golf.stratigraphy_from("eta", dz=0.1)
+        golf.register_section("testsection", section.StrikeSection(distance_idx=10))
+        assert "testsection" in golf.sections.keys()
+        slc = golf.sections["testsection"]
         assert issubclass(type(slc), section.BaseSection)
 
     def test_register_planform(self):
         golf = cube.DataCube(golf_path)
-        golf.stratigraphy_from('eta', dz=0.1)
-        golf.register_planform(
-            'testplanform', plan.Planform(idx=10))
+        golf.stratigraphy_from("eta", dz=0.1)
+        golf.register_planform("testplanform", plan.Planform(idx=10))
         assert golf.planforms is golf.planform_set
         assert len(golf.planforms.keys()) == 1
-        assert 'testplanform' in golf.planforms.keys()
-        with pytest.raises(TypeError, match=r'`PlanformInstance` .*'):
-            golf.register_planform('fail1', 'astring')
-        with pytest.raises(TypeError, match=r'`PlanformInstance` .*'):
-            golf.register_planform('fail2', 22)
-        with pytest.raises(TypeError, match=r'`name` .*'):
+        assert "testplanform" in golf.planforms.keys()
+        with pytest.raises(TypeError, match=r"`PlanformInstance` .*"):
+            golf.register_planform("fail1", "astring")
+        with pytest.raises(TypeError, match=r"`PlanformInstance` .*"):
+            golf.register_planform("fail2", 22)
+        with pytest.raises(TypeError, match=r"`name` .*"):
             golf.register_planform(22, plan.Planform(idx=10))
         returnedplanform = golf.register_planform(
-            'returnedplanform', plan.Planform(idx=10),
-            return_planform=True)
-        assert returnedplanform.name == 'returnedplanform'
+            "returnedplanform", plan.Planform(idx=10), return_planform=True
+        )
+        assert returnedplanform.name == "returnedplanform"
 
     def test_register_plan_legacy_method(self):
         """This tests the shorthand named version."""
         golf = cube.DataCube(golf_path)
-        golf.register_plan(
-            'testplanform', plan.Planform(idx=10))
+        golf.register_plan("testplanform", plan.Planform(idx=10))
         assert golf.planforms is golf.planform_set
         assert len(golf.planforms.keys()) == 1
-        assert 'testplanform' in golf.planforms.keys()
+        assert "testplanform" in golf.planforms.keys()
 
     def test_planforms_slice_op(self):
         golf = cube.DataCube(golf_path)
-        golf.stratigraphy_from('eta', dz=0.1)
-        golf.register_planform(
-            'testplanform', plan.Planform(idx=10))
-        assert 'testplanform' in golf.planforms.keys()
-        slc = golf.planforms['testplanform']
+        golf.stratigraphy_from("eta", dz=0.1)
+        golf.register_planform("testplanform", plan.Planform(idx=10))
+        assert "testplanform" in golf.planforms.keys()
+        slc = golf.planforms["testplanform"]
         assert issubclass(type(slc), plan.BasePlanform)
 
     def test_nostratigraphy_default(self):
@@ -161,11 +155,10 @@ class TestDataCubeNoStratigraphy:
 
     def test_nostratigraphy_default_attribute_derived_variable(self):
         golf = cube.DataCube(golf_path)
-        golf.register_section(
-            'testsection', section.StrikeSection(distance_idx=10))
+        golf.register_section("testsection", section.StrikeSection(distance_idx=10))
         assert golf._knows_stratigraphy is False
         with pytest.raises(utils.NoStratigraphyError):
-            golf.sections['testsection']['velocity'].strat.as_stratigraphy()
+            golf.sections["testsection"]["velocity"].strat.as_stratigraphy()
 
     def test_fixeddatacube_init_varset(self):
         assert type(self.fixeddatacube.varset) is plot.VariableSet
@@ -174,7 +167,7 @@ class TestDataCubeNoStratigraphy:
         assert self.fixeddatacube.data_path == golf_path
 
     def test_fixeddatacube_init_dataio(self):
-        assert hasattr(self.fixeddatacube, 'dataio')
+        assert hasattr(self.fixeddatacube, "dataio")
 
     def test_fixeddatacube_init_variables(self):
         assert type(self.fixeddatacube.variables) is list
@@ -229,77 +222,74 @@ class TestDataCubeNoStratigraphy:
 
     def test_section_no_stratigraphy(self):
         sc = section.StrikeSection(self.fixeddatacube, distance_idx=10)
-        _ = sc['velocity'][:, 1]
-        assert not hasattr(sc, 'strat_attr')
+        _ = sc["velocity"][:, 1]
+        assert not hasattr(sc, "strat_attr")
         with pytest.raises(utils.NoStratigraphyError):
             _ = sc.strat_attr
         with pytest.raises(utils.NoStratigraphyError):
-            _ = sc['velocity'].strat.as_preserved()
+            _ = sc["velocity"].strat.as_preserved()
 
     def test_show_section_mocked_BaseSection_show(self):
         golf = cube.DataCube(golf_path)
-        golf.register_section(
-            'displaysection', section.StrikeSection(distance_idx=10))
-        golf.sections['displaysection'].show = mock.MagicMock()
-        mocked = golf.sections['displaysection'].show
+        golf.register_section("displaysection", section.StrikeSection(distance_idx=10))
+        golf.sections["displaysection"].show = mock.MagicMock()
+        mocked = golf.sections["displaysection"].show
         # no arguments is an error
-        with pytest.raises(TypeError, match=r'.* missing 2 .*'):
+        with pytest.raises(TypeError, match=r".* missing 2 .*"):
             golf.show_section()
         # one argument is an error
-        with pytest.raises(TypeError, match=r'.* missing 1 .*'):
-            golf.show_section('displaysection')
+        with pytest.raises(TypeError, match=r".* missing 1 .*"):
+            golf.show_section("displaysection")
         # three arguments is an error
-        with pytest.raises(TypeError, match=r'.* takes 3 .*'):
-            golf.show_section('one', 'two', 'three')
+        with pytest.raises(TypeError, match=r".* takes 3 .*"):
+            golf.show_section("one", "two", "three")
         # two arguments passes to BaseSection.show()
-        golf.show_section('displaysection', 'eta')
+        golf.show_section("displaysection", "eta")
         assert mocked.call_count == 1
         # kwargs should be passed along to BaseSection.show
-        golf.show_section('displaysection', 'eta', ax=100)
+        golf.show_section("displaysection", "eta", ax=100)
         assert mocked.call_count == 2
-        mocked.assert_called_with('eta', ax=100)
+        mocked.assert_called_with("eta", ax=100)
         # first arg must be a string
-        with pytest.raises(TypeError, match=r'`name` was not .*'):
-            golf.show_section(1, 'two')
+        with pytest.raises(TypeError, match=r"`name` was not .*"):
+            golf.show_section(1, "two")
 
     def test_show_planform_mocked_Planform_show(self):
         golf = cube.DataCube(golf_path)
-        golf.register_planform(
-            'displayplan', plan.Planform(idx=-1))
-        golf.planforms['displayplan'].show = mock.MagicMock()
-        mocked = golf.planforms['displayplan'].show
+        golf.register_planform("displayplan", plan.Planform(idx=-1))
+        golf.planforms["displayplan"].show = mock.MagicMock()
+        mocked = golf.planforms["displayplan"].show
         # no arguments is an error
-        with pytest.raises(TypeError, match=r'.* missing 2 .*'):
+        with pytest.raises(TypeError, match=r".* missing 2 .*"):
             golf.show_planform()
         # one argument is an error
-        with pytest.raises(TypeError, match=r'.* missing 1 .*'):
-            golf.show_planform('displayplan')
+        with pytest.raises(TypeError, match=r".* missing 1 .*"):
+            golf.show_planform("displayplan")
         # three arguments is an error
-        with pytest.raises(TypeError, match=r'.* takes 3 .*'):
-            golf.show_planform('one', 'two', 'three')
+        with pytest.raises(TypeError, match=r".* takes 3 .*"):
+            golf.show_planform("one", "two", "three")
         # two arguments passes to BaseSection.show()
-        golf.show_planform('displayplan', 'eta')
+        golf.show_planform("displayplan", "eta")
         assert mocked.call_count == 1
         # kwargs should be passed along to BaseSection.show
-        golf.show_planform('displayplan', 'eta', ax=100)
+        golf.show_planform("displayplan", "eta", ax=100)
         assert mocked.call_count == 2
-        mocked.assert_called_with('eta', ax=100)
+        mocked.assert_called_with("eta", ax=100)
         # first arg must be a string
-        with pytest.raises(TypeError, match=r'`name` was not .*'):
-            golf.show_planform(1, 'two')
+        with pytest.raises(TypeError, match=r"`name` was not .*"):
+            golf.show_planform(1, "two")
 
 
 class TestDataCubeWithStratigraphy:
-
     # create a fixed cube for variable existing, type checks
     fixeddatacube = cube.DataCube(golf_path)
-    fixeddatacube.stratigraphy_from('eta', dz=0.1)  # compute stratigraphy for the cube
+    fixeddatacube.stratigraphy_from("eta", dz=0.1)  # compute stratigraphy for the cube
 
     # test setting all the properties / attributes
     def test_fixeddatacube_set_varset(self):
         new_varset = plot.VariableSet()
         self.fixeddatacube.varset = new_varset
-        assert hasattr(self.fixeddatacube, 'varset')
+        assert hasattr(self.fixeddatacube, "varset")
         assert type(self.fixeddatacube.varset) is plot.VariableSet
         assert self.fixeddatacube.varset is new_varset
 
@@ -309,7 +299,7 @@ class TestDataCubeWithStratigraphy:
 
     def test_fixeddatacube_set_data_path(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.data_path = '/trying/to/change/path.nc'
+            self.fixeddatacube.data_path = "/trying/to/change/path.nc"
 
     def test_fixeddatacube_set_dataio(self):
         with pytest.raises(AttributeError):
@@ -317,20 +307,19 @@ class TestDataCubeWithStratigraphy:
 
     def test_fixeddatacube_set_variables_list(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.variables = ['is', 'a', 'list']
+            self.fixeddatacube.variables = ["is", "a", "list"]
 
     def test_fixeddatacube_set_variables_dict(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.variables = {
-                'is': True, 'a': True, 'dict': True}
+            self.fixeddatacube.variables = {"is": True, "a": True, "dict": True}
 
     def test_fixeddatacube_set_planform_set_list(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.planform_set = ['is', 'a', 'list']
+            self.fixeddatacube.planform_set = ["is", "a", "list"]
 
     def test_fixeddatacube_set_planform_set_dict(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.planform_set = {'is': True, 'a': True, 'dict': True}
+            self.fixeddatacube.planform_set = {"is": True, "a": True, "dict": True}
 
     def test_fixeddatacube_set_plans(self):
         with pytest.raises(AttributeError):
@@ -338,38 +327,38 @@ class TestDataCubeWithStratigraphy:
 
     def test_fixeddatacube_set_section_set_list(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.section_set = ['is', 'a', 'list']
+            self.fixeddatacube.section_set = ["is", "a", "list"]
 
     def test_fixeddatacube_set_section_set_dict(self):
         with pytest.raises(AttributeError):
-            self.fixeddatacube.section_set = {
-                'is': True, 'a': True, 'dict': True}
+            self.fixeddatacube.section_set = {"is": True, "a": True, "dict": True}
 
     def test_fixedset_set_sections(self):
         with pytest.raises(AttributeError):
             self.fixeddatacube.sections = 10
 
     def test_export_frozen_variable(self):
-        frzn = self.fixeddatacube.export_frozen_variable('velocity')
+        frzn = self.fixeddatacube.export_frozen_variable("velocity")
         assert frzn.ndim == 3
 
     def test_section_with_stratigraphy(self):
-        assert hasattr(self.fixeddatacube, 'strat_attr')
+        assert hasattr(self.fixeddatacube, "strat_attr")
         sc = section.StrikeSection(self.fixeddatacube, distance_idx=10)
         assert sc.strat_attr is self.fixeddatacube.strat_attr
-        _take = sc['velocity'][:, 1]
+        _take = sc["velocity"][:, 1]
         assert _take.shape == (self.fixeddatacube.shape[0],)
-        assert hasattr(sc, 'strat_attr')
-        _take2 = sc['velocity'].strat.as_preserved()
-        assert _take2.shape == (self.fixeddatacube.shape[0], self.fixeddatacube.shape[2])
+        assert hasattr(sc, "strat_attr")
+        _take2 = sc["velocity"].strat.as_preserved()
+        assert _take2.shape == (
+            self.fixeddatacube.shape[0],
+            self.fixeddatacube.shape[2],
+        )
 
 
 class TestStratigraphyCube:
-
     # create a fixed cube for variable existing, type checks
     fixeddatacube = cube.DataCube(golf_path)
-    fixedstratigraphycube = cube.StratigraphyCube.from_DataCube(
-        fixeddatacube, dz=0.1)
+    fixedstratigraphycube = cube.StratigraphyCube.from_DataCube(fixeddatacube, dz=0.1)
 
     def test_no_tT_StratigraphyCube(self):
         with pytest.raises(AttributeError):
@@ -378,84 +367,80 @@ class TestStratigraphyCube:
             _ = self.fixedstratigraphycube.T
 
     def test_export_frozen_variable(self):
-        frzn = self.fixedstratigraphycube.export_frozen_variable('time')
+        frzn = self.fixedstratigraphycube.export_frozen_variable("time")
         assert frzn.ndim == 3
 
     def test_StratigraphyCube_inherit_varset(self):
         # when creating from DataCube, varset should be inherited
-        tempsc = cube.StratigraphyCube.from_DataCube(
-            self.fixeddatacube, dz=1)
+        tempsc = cube.StratigraphyCube.from_DataCube(self.fixeddatacube, dz=1)
         assert tempsc.varset is self.fixeddatacube.varset
 
 
 class TestStratigraphyCubeSubsidence:
-    
     # create a cube with some uniform subsidence
     datacube = cube.DataCube(golf_path)
     subsstratcube = cube.StratigraphyCube.from_DataCube(
-        datacube, dz=0.2, sigma_dist=0.005)
-    nosubs = cube.StratigraphyCube.from_DataCube(
-        datacube, dz=0.2)
+        datacube, dz=0.2, sigma_dist=0.005
+    )
+    nosubs = cube.StratigraphyCube.from_DataCube(datacube, dz=0.2)
 
     def test_subsidence_cube(self):
         assert self.subsstratcube.sigma_dist == 0.005
         assert self.nosubs.sigma_dist is None
         assert self.subsstratcube.sigma_dist != self.nosubs.sigma_dist
-        assert self.nosubs.strata[0, -1, -1] == -2.
-        assert self.nosubs.strata[-1, -1, -1] == -2.
-        _expected_0 = -2. - (self.subsstratcube.sigma_dist *
-                             (self.datacube.shape[0]-1))
-        assert self.subsstratcube.strata[0, -1, -1] == \
-            pytest.approx(_expected_0)
-        _expected_last = -2.
-        assert self.subsstratcube.strata[-1, -1, -1] == \
-            pytest.approx(_expected_last)
+        assert self.nosubs.strata[0, -1, -1] == -2.0
+        assert self.nosubs.strata[-1, -1, -1] == -2.0
+        _expected_0 = -2.0 - (
+            self.subsstratcube.sigma_dist * (self.datacube.shape[0] - 1)
+        )
+        assert self.subsstratcube.strata[0, -1, -1] == pytest.approx(_expected_0)
+        _expected_last = -2.0
+        assert self.subsstratcube.strata[-1, -1, -1] == pytest.approx(_expected_last)
 
 
 class TestFrozenStratigraphyCube:
-
     fixeddatacube = cube.DataCube(golf_path)
-    fixedstratigraphycube = cube.StratigraphyCube.from_DataCube(
-        fixeddatacube, dz=0.1)
-    frozenstratigraphycube = fixedstratigraphycube.export_frozen_variable(
-        'time')
+    fixedstratigraphycube = cube.StratigraphyCube.from_DataCube(fixeddatacube, dz=0.1)
+    frozenstratigraphycube = fixedstratigraphycube.export_frozen_variable("time")
 
     def test_types(self):
-        assert isinstance(self.frozenstratigraphycube,
-                          xr.core.dataarray.DataArray)
+        assert isinstance(self.frozenstratigraphycube, xr.core.dataarray.DataArray)
 
     def test_matches_underlying_data(self):
         assert not (self.frozenstratigraphycube is self.fixedstratigraphycube)
         frzn_log = self.frozenstratigraphycube.values[
-            ~np.isnan(self.frozenstratigraphycube.values)]
-        fixd_log = self.fixedstratigraphycube['time'].values[
-            ~np.isnan(self.fixedstratigraphycube['time'].values)]
+            ~np.isnan(self.frozenstratigraphycube.values)
+        ]
+        fixd_log = self.fixedstratigraphycube["time"].values[
+            ~np.isnan(self.fixedstratigraphycube["time"].values)
+        ]
         assert frzn_log.shape == fixd_log.shape
         assert np.all(fixd_log == frzn_log)
 
 
 class TestLegacyPyDeltaRCMCube:
-
     def test_init_cube_from_path_rcm8(self):
         with pytest.warns(UserWarning) as record:
             rcm8cube = cube.DataCube(rcm8_path)
         assert rcm8cube._data_path == rcm8_path
-        assert rcm8cube.dataio.io_type == 'netcdf'
+        assert rcm8cube.dataio.io_type == "netcdf"
         assert rcm8cube._planform_set == {}
         assert rcm8cube._section_set == {}
         assert type(rcm8cube.varset) is plot.VariableSet
 
         # check that two warnings were raised
-        assert any(re.match(
-            r'Coordinates for "time", .*',
-            _warning.message.args[0]) for _warning in record)
+        assert any(
+            re.match(r'Coordinates for "time", .*', _warning.message.args[0])
+            for _warning in record
+        )
 
-        assert any(re.match(
-            r'No associated metadata .*',
-            _warning.message.args[0]) for _warning in record)
+        assert any(
+            re.match(r"No associated metadata .*", _warning.message.args[0])
+            for _warning in record
+        )
 
     def test_warning_netcdf_no_metadata(self):
-        with pytest.warns(UserWarning, match=r'No associated metadata'):
+        with pytest.warns(UserWarning, match=r"No associated metadata"):
             _ = cube.DataCube(rcm8_path)
 
     def test_metadata_none_nometa(self):
@@ -465,82 +450,74 @@ class TestLegacyPyDeltaRCMCube:
 
 
 class TestCubesFromDictionary:
-
     fixeddatacube = cube.DataCube(golf_path)
 
     def test_DataCube_one_dataset(self):
-        eta_data = self.fixeddatacube['eta'][:, :, :]
-        dict_cube = cube.DataCube(
-            {'eta': eta_data})
-        assert isinstance(dict_cube['eta'], xr.core.dataarray.DataArray)
+        eta_data = self.fixeddatacube["eta"][:, :, :]
+        dict_cube = cube.DataCube({"eta": eta_data})
+        assert isinstance(dict_cube["eta"], xr.core.dataarray.DataArray)
         assert dict_cube.shape == self.fixeddatacube.shape
-        assert np.all(dict_cube['eta'] == self.fixeddatacube['eta'][:, :, :])
+        assert np.all(dict_cube["eta"] == self.fixeddatacube["eta"][:, :, :])
 
     def test_DataCube_one_dataset_numpy(self):
-        eta_data = np.array(self.fixeddatacube['eta'][:, :, :])
-        dict_cube = cube.DataCube(
-            {'eta': eta_data})
+        eta_data = np.array(self.fixeddatacube["eta"][:, :, :])
+        dict_cube = cube.DataCube({"eta": eta_data})
         # the return is always dataarray!
-        assert isinstance(dict_cube['eta'], xr.core.dataarray.DataArray)
+        assert isinstance(dict_cube["eta"], xr.core.dataarray.DataArray)
         assert dict_cube.shape == self.fixeddatacube.shape
 
     def test_DataCube_one_dataset_partial(self):
-        eta_data = self.fixeddatacube['eta'][:30, :, :]
-        dict_cube = cube.DataCube(
-            {'eta': eta_data})
-        assert np.all(dict_cube['eta'] == self.fixeddatacube['eta'][:30, :, :])
+        eta_data = self.fixeddatacube["eta"][:30, :, :]
+        dict_cube = cube.DataCube({"eta": eta_data})
+        assert np.all(dict_cube["eta"] == self.fixeddatacube["eta"][:30, :, :])
 
     def test_DataCube_two_dataset(self):
-        eta_data = self.fixeddatacube['eta'][:, :, :]
-        vel_data = self.fixeddatacube['velocity'][:, :, :]
-        dict_cube = cube.DataCube(
-            {'eta': eta_data,
-             'velocity': vel_data})
-        assert np.all(dict_cube['eta'] == self.fixeddatacube['eta'][:, :, :])
-        assert np.all(dict_cube['velocity'] == self.fixeddatacube['velocity'][:, :, :])
+        eta_data = self.fixeddatacube["eta"][:, :, :]
+        vel_data = self.fixeddatacube["velocity"][:, :, :]
+        dict_cube = cube.DataCube({"eta": eta_data, "velocity": vel_data})
+        assert np.all(dict_cube["eta"] == self.fixeddatacube["eta"][:, :, :])
+        assert np.all(dict_cube["velocity"] == self.fixeddatacube["velocity"][:, :, :])
 
-    @pytest.mark.xfail(NotImplementedError, reason='not implemented', strict=True)
+    @pytest.mark.xfail(NotImplementedError, reason="not implemented", strict=True)
     def test_StratigraphyCube_from_etas(self):
-        eta_data = self.fixeddatacube['eta'][:, :, :]
-        _ = cube.StratigraphyCube({'eta': eta_data})
+        eta_data = self.fixeddatacube["eta"][:, :, :]
+        _ = cube.StratigraphyCube({"eta": eta_data})
 
-    @pytest.mark.xfail(NotImplementedError, reason='not implemented', strict=True)
+    @pytest.mark.xfail(NotImplementedError, reason="not implemented", strict=True)
     def test_StratigraphyCube_from_etas_numpy(self):
-        eta_data = self.fixeddatacube['eta'][:, :, :]
-        _ = cube.StratigraphyCube({'eta': np.array(eta_data)})
+        eta_data = self.fixeddatacube["eta"][:, :, :]
+        _ = cube.StratigraphyCube({"eta": np.array(eta_data)})
 
     def test_no_metadata_integrated(self):
-        eta_data = self.fixeddatacube['eta'][:30, :, :]
-        dict_cube = cube.DataCube(
-            {'eta': eta_data})
+        eta_data = self.fixeddatacube["eta"][:30, :, :]
+        dict_cube = cube.DataCube({"eta": eta_data})
         with pytest.raises(AttributeError):
             dict_cube.meta
 
 
 class TestLandsatCube:
-
-    with pytest.warns(UserWarning, match=r'No associated metadata'):
+    with pytest.warns(UserWarning, match=r"No associated metadata"):
         landsatcube = cube.DataCube(hdf_path)
 
     def test_init_cube_from_path_hdf5(self):
-        with pytest.warns(UserWarning, match=r'No associated metadata'):
+        with pytest.warns(UserWarning, match=r"No associated metadata"):
             hdfcube = cube.DataCube(hdf_path)
         assert hdfcube._data_path == hdf_path
-        assert hdfcube.dataio.io_type == 'hdf5'
+        assert hdfcube.dataio.io_type == "hdf5"
         assert hdfcube._planform_set == {}
         assert hdfcube._section_set == {}
         assert type(hdfcube.varset) is plot.VariableSet
 
     def test_read_Blue_intomemory(self):
         assert self.landsatcube._dataio._in_memory_data == {}
-        assert self.landsatcube.variables == ['Blue', 'Green', 'NIR', 'Red']
+        assert self.landsatcube.variables == ["Blue", "Green", "NIR", "Red"]
         assert len(self.landsatcube.variables) == 4
 
-        self.landsatcube.read('Blue')
+        self.landsatcube.read("Blue")
         assert len(self.landsatcube.dataio._in_memory_data) == 1
 
     def test_read_all_intomemory(self):
-        assert self.landsatcube.variables == ['Blue', 'Green', 'NIR', 'Red']
+        assert self.landsatcube.variables == ["Blue", "Green", "NIR", "Red"]
         assert len(self.landsatcube.variables) == 4
 
         self.landsatcube.read(True)
@@ -551,5 +528,5 @@ class TestLandsatCube:
             self.landsatcube.read(5)
 
     def test_get_coords(self):
-        assert self.landsatcube.coords == ['time', 'x', 'y']
-        assert self.landsatcube._coords == ['time', 'x', 'y']
+        assert self.landsatcube.coords == ["time", "x", "y"]
+        assert self.landsatcube._coords == ["time", "x", "y"]


### PR DESCRIPTION
Broken test in build from io.

The underlying issue was a warning being raised by third-party package (xarray) and that throwing off the order or warnings raised by our io module. The test depended on that order. 

I added warning handling to the line that xarray raises the warning at (so our package will be quieter), and I fixed the test to not depend on the warning order any more, but just check for warnings being raised.