### PR TITLE
Non-breaking MPM change

### DIFF
--- a/deltametrics/_version.py
+++ b/deltametrics/_version.py
@@ -2,4 +2,4 @@ def __version__():
     """
     Private version declaration, gets assigned to dm.__version__ during import
     """
-    return "0.4.2"
+    return "0.4.3"

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1763,12 +1763,10 @@ def shaw_opening_angle_method(below_mask, numviews=3):
 def _custom_closing(img, disksize):
     """Custom function for the binary closing.
 
-    Custom function is implemented to handle iteration until convergence, and
-    use Fourier transform implementation of the morphological operations.
+    Custom function is implemented to use Fourier transform implementation of
+    the morphological operations.
 
-    Iteration is repeated until specified tolerance (1 pixel) and maximum
-    number of iterations (100). In most (all?) cases, two iterations is
-    sufficient.
+    This operation is equivalent to scikit-image.morphology.binary_closing.
 
     The FFT implementation is after
     https://www.cs.utep.edu/vladik/misha5.pdf
@@ -1789,6 +1787,7 @@ def _custom_closing(img, disksize):
     r = (disksize // 2) + 1  # kernel radius, i.e. half the width of disk
     _iter = 0  # count number of closings, cap at 100
 
+    # binary_closing is dilation followed by erosion
     _dilated = _dilate(img, disk)
     _newimg = _erode(_dilated, disk, r)
 


### PR DESCRIPTION
This is a non-breaking change to the morphological planform operations, for the sake of a small bug fix, and considerable improvement in speed.

1. This PR removes iterations that were identified in #142. As far as I can tell, there was no actual iteration happening in the code there, but instead there was only 99 repetitions of the same binary closing (`img` was reused again and again). Also, as far as I can tell, the idea of iterations is only applicable in the case of grayscale images. In binary operations, the iteration converges after a single iteration. Now, there is a single iteration of the operation.
2. The implementation is changed to an FFT-based implementation of the morphological closing. This is much faster, and especially as the image size increases and the kernel size increases.

| max disk size | old    | new |
| ------------------- | ------- | ------ |
| 8                      | 1.078 s | 0.012 s  |
| 20                    | 21.29 s | 0.026 s   |
| 50                    | >10 min | 0.08 s   |

Test to make sure this is a non breaking change (L-->R: old, new, diff)
![MPM_compare_actual](https://github.com/DeltaRCM/DeltaMetrics/assets/8801322/af7dc546-9e0d-4331-ab61-4b225bff5f71)


Test to make sure multiple iterations don't do anything (L-->R: old 100 iter, old 0 iter, diff)

![MPM_compare_100iterations](https://github.com/DeltaRCM/DeltaMetrics/assets/8801322/540bd3cc-8707-41ff-a533-050fc2f7250e)

closes #142 
