### PR TITLE
Fix failing test_time_variable

### DIFF
--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -660,7 +660,7 @@ class TestComputeSedimentograph:
             self.golfstrat['time'],
             num_sections=50,
             last_section_radius=2750,
-            sediment_bins=np.linspace(0, golfcube.t[-1], num=5),
+            sediment_bins=np.linspace(0, float(golfcube.t[-1]), num=5),
             background=background,
             origin_idx=[3, 100])
         assert np.all(np.logical_or(s <= 1, np.isnan(s)))


### PR DESCRIPTION
This pull request fixes a failing test in `test_strat.py`. I believe it is caused by how *numpy2* interacts with *xarray* `DataArray`s.

The error is caused by the following,
```python
np.linspace(0, float(golfcube.t[-1]), num=5)
```
which raised the following error,
```python
ValueError: dimensions () must have the same length as the number of data dimensions, ndim=1
```

I've fixed this by converting `golfcube.t[-1]` to a `float` (rather than a `DataArray`).

I could, instead, have done the following
```python
np.linspace(0, golfcube.t[-1].data, num=5)
```

Both seem to work and are backward compatible.