### PR TITLE
Drop Python 3.8 from testing and add Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,10 +51,10 @@ jobs:
       uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - name: Set up Python 3.9
+    - name: Set up Python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.12'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -63,7 +63,8 @@ jobs:
         sudo apt update -y && sudo apt install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended dvipng
     - name: Install DeltaMetrics
       run: |
-        python setup.py install
+        pip install setuptools
+        pip install --no-build-isolation .
     - name: Build and test documentation
       run: |
         (cd docs && make docs)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.11', '3.12']
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
This pull request drops testing with Python 3.8, 3.9, and 3.10 and adds Python 3.11 and 3.12. Now that Python 3.13 is released, 3.11 should really be the _minimum_ version and we should be testing with 3.13, but I'll address that in a separate pull request because some additional (but small) changes to *detlametrics* are necessary to make 3.13 happen.

