### PR TITLE
Absolute import of the deltametrics.plot module

### DIFF
--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -16,7 +16,7 @@ from deltametrics.strat import _determine_strat_coordinates
 from deltametrics.strat import BoxyStratigraphyAttributes
 from deltametrics.strat import MeshStratigraphyAttributes
 from deltametrics.strat import compute_boxy_stratigraphy_coordinates
-from . import plot
+from deltametrics.plot import VariableSet
 from deltametrics.io import DictionaryIO
 from deltametrics.io import NetCDFIO
 
@@ -87,7 +87,7 @@ class BaseCube(abc.ABC):
         if varset:
             self.varset = varset
         else:
-            self.varset = plot.VariableSet()
+            self.varset = VariableSet()
 
         # some undocumented aliases
         self.plans = self._planform_set
@@ -190,7 +190,7 @@ class BaseCube(abc.ABC):
 
     @varset.setter
     def varset(self, var):
-        if type(var) is plot.VariableSet:
+        if type(var) is VariableSet:
             self._varset = var
         else:
             raise TypeError("Pass a valid VariableSet instance.")

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -13,7 +13,7 @@ import warnings
 from deltametrics.utils import is_ndarray_or_xarray
 from . import cube
 from . import plan
-from . import plot
+from deltametrics.plot import append_colorbar
 
 
 class BaseMask(abc.ABC):
@@ -263,7 +263,7 @@ class BaseMask(abc.ABC):
         im = ax.imshow(self.integer_mask, cmap=cmap, extent=_extent, **kwargs)
 
         if colorbar:
-            _ = plot.append_colorbar(im, ax)
+            append_colorbar(im, ax)
 
         if not ticks:
             ax.set_xticks([], minor=[])

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -18,10 +18,11 @@ from numba import njit, prange, set_num_threads
 from . import mask
 from . import cube
 from . import section as dm_section
-from . import plot
+from deltametrics.plot import VariableInfo
+from deltametrics.plot import VariableSet
+from deltametrics.plot import append_colorbar
 from deltametrics.utils import _points_in_polygon
 from deltametrics.utils import is_ndarray_or_xarray
-
 
 class BasePlanform(abc.ABC):
     """Base planform object.
@@ -138,7 +139,7 @@ class BasePlanform(abc.ABC):
         )
 
         if colorbar:
-            cb = plot.append_colorbar(im, ax)
+            cb = append_colorbar(im, ax)
             if colorbar_label:
                 _colorbar_label = (
                     varinfo.label if (colorbar_label is True) else str(colorbar_label)
@@ -362,7 +363,7 @@ class Planform(BasePlanform):
         _varinfo = (
             self.cube.varset[var]
             if issubclass(type(self.cube), cube.BaseCube)
-            else plot.VariableSet()[var]
+            else VariableSet()[var]
         )
         _field = self[var]
 
@@ -436,7 +437,7 @@ class SpecialtyPlanform(BasePlanform):
         """
         super().__init__(planform_type, *args, **kwargs)
 
-        self._default_varinfo = plot.VariableInfo("data", label="data")
+        self._default_varinfo = VariableInfo("data", label="data")
 
     @property
     @abc.abstractmethod
@@ -688,10 +689,10 @@ class OpeningAnglePlanform(SpecialtyPlanform):
         self._below_mask = None
 
         # set variable info display options
-        self._opening_angles_varinfo = plot.VariableInfo(
+        self._opening_angles_varinfo = VariableInfo(
             "opening_angles", cmap=plt.cm.jet, label="opening angle"
         )
-        self._below_mask_varinfo = plot.VariableInfo(
+        self._below_mask_varinfo = VariableInfo(
             "below_mask", cmap=plt.cm.gray, label="where below"
         )
         self._default_varinfo = self._opening_angles_varinfo
@@ -989,7 +990,7 @@ class MorphologicalPlanform(SpecialtyPlanform):
         self._below_mask = None
 
         # set variable info display options
-        self._mean_image_varinfo = plot.VariableInfo("mean_image", label="mean image")
+        self._mean_image_varinfo = VariableInfo("mean_image", label="mean image")
         self._default_varinfo = self._mean_image_varinfo
 
         # check for input or allowable emptiness

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 
 from . import cube
-from . import plot
 from . import mask
 from . import plan
 from deltametrics.utils import NoStratigraphyError
@@ -600,6 +599,12 @@ class BaseSection(abc.ABC):
 
         .. plot:: section/section_demo_quick_strat.py
         """
+        from deltametrics.plot import VariableSet
+        from deltametrics.plot import append_colorbar
+        from deltametrics.plot import get_display_arrays
+        from deltametrics.plot import get_display_limits
+        from deltametrics.plot import get_display_lines
+
         # check that someting is attached
         if self._underlying is None:
             raise AttributeError(
@@ -625,11 +630,11 @@ class BaseSection(abc.ABC):
             _varinfo = (
                 self._underlying.varset[SectionAttribute]
                 if issubclass(type(self._underlying), cube.BaseCube)
-                else plot.VariableSet()[SectionAttribute]
+                else VariableSet()[SectionAttribute]
             )
             # main routines for plot styles
             if style in ["shade", "shaded"]:
-                _data, _X, _Y = plot.get_display_arrays(
+                _data, _X, _Y = get_display_arrays(
                     SectionVariableInstance, data=data
                 )
                 ci = ax.pcolormesh(
@@ -644,7 +649,7 @@ class BaseSection(abc.ABC):
                     rasterized=True,
                 )
             elif style in ["line", "lines"]:
-                _data, _segments = plot.get_display_lines(
+                _data, _segments = get_display_lines(
                     SectionVariableInstance, data=data
                 )
                 lc = LineCollection(_segments, cmap=_varinfo.cmap)
@@ -656,7 +661,7 @@ class BaseSection(abc.ABC):
 
             # style adjustments
             if colorbar:
-                cb = plot.append_colorbar(ci, ax)
+                cb = append_colorbar(ci, ax)
                 if colorbar_label:
                     _colorbar_label = (
                         _varinfo.label
@@ -680,7 +685,7 @@ class BaseSection(abc.ABC):
                 )
 
             # set the limits of the plot accordingly
-            xmin, xmax, ymin, ymax = plot.get_display_limits(
+            xmin, xmax, ymin, ymax = get_display_limits(
                 SectionVariableInstance, data=data
             )
             ax.set_xlim(xmin, xmax)

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -7,7 +7,7 @@ import xarray as xr
 
 from deltametrics import cube
 
-from deltametrics import plot
+from deltametrics.plot import VariableSet
 from deltametrics.section import BaseSection
 from deltametrics.section import StrikeSection
 from deltametrics import plan
@@ -32,7 +32,7 @@ class TestDataCubeNoStratigraphy:
         assert golf.dataio.io_type == "netcdf"
         assert golf._planform_set == {}
         assert golf._section_set == {}
-        assert type(golf.varset) is plot.VariableSet
+        assert type(golf.varset) is VariableSet
 
     def test_error_init_empty_cube(self):
         with pytest.raises(TypeError):
@@ -67,19 +67,19 @@ class TestDataCubeNoStratigraphy:
         assert golf._knows_stratigraphy is True
 
     def test_init_with_shared_varset_prior(self):
-        shared_varset = plot.VariableSet()
+        shared_varset = VariableSet()
         golf1 = cube.DataCube(golf_path, varset=shared_varset)
         golf2 = cube.DataCube(golf_path, varset=shared_varset)
-        assert type(golf1.varset) is plot.VariableSet
-        assert type(golf2.varset) is plot.VariableSet
+        assert type(golf1.varset) is VariableSet
+        assert type(golf2.varset) is VariableSet
         assert golf1.varset is shared_varset
         assert golf1.varset is golf2.varset
 
     def test_init_with_shared_varset_from_first(self):
         golf1 = cube.DataCube(golf_path)
         golf2 = cube.DataCube(golf_path, varset=golf1.varset)
-        assert type(golf1.varset) is plot.VariableSet
-        assert type(golf2.varset) is plot.VariableSet
+        assert type(golf1.varset) is VariableSet
+        assert type(golf2.varset) is VariableSet
         assert golf1.varset is golf2.varset
 
     def test_slice_op(self):
@@ -162,7 +162,7 @@ class TestDataCubeNoStratigraphy:
             golf.sections["testsection"]["velocity"].strat.as_stratigraphy()
 
     def test_fixeddatacube_init_varset(self):
-        assert type(self.fixeddatacube.varset) is plot.VariableSet
+        assert type(self.fixeddatacube.varset) is VariableSet
 
     def test_fixeddatacube_init_data_path(self):
         assert self.fixeddatacube.data_path == golf_path
@@ -288,10 +288,10 @@ class TestDataCubeWithStratigraphy:
 
     # test setting all the properties / attributes
     def test_fixeddatacube_set_varset(self):
-        new_varset = plot.VariableSet()
+        new_varset = VariableSet()
         self.fixeddatacube.varset = new_varset
         assert hasattr(self.fixeddatacube, "varset")
-        assert type(self.fixeddatacube.varset) is plot.VariableSet
+        assert type(self.fixeddatacube.varset) is VariableSet
         assert self.fixeddatacube.varset is new_varset
 
     def test_fixeddatacube_set_varset_bad_type(self):
@@ -427,7 +427,7 @@ class TestLegacyPyDeltaRCMCube:
         assert rcm8cube.dataio.io_type == "netcdf"
         assert rcm8cube._planform_set == {}
         assert rcm8cube._section_set == {}
-        assert type(rcm8cube.varset) is plot.VariableSet
+        assert type(rcm8cube.varset) is VariableSet
 
         # check that two warnings were raised
         assert any(
@@ -507,7 +507,7 @@ class TestLandsatCube:
         assert hdfcube.dataio.io_type == "hdf5"
         assert hdfcube._planform_set == {}
         assert hdfcube._section_set == {}
-        assert type(hdfcube.varset) is plot.VariableSet
+        assert type(hdfcube.varset) is VariableSet
 
     def test_read_Blue_intomemory(self):
         assert self.landsatcube._dataio._in_memory_data == {}


### PR DESCRIPTION
This pull request uses absolute imports for the *deltametrics.plot* module and also directly imports objects from the module.

To avoid circular imports, I've moved some of the imports from *plot* into the `BaseSection.show` method as local imports.

ref: #146