### PR TITLE
Fix circular imports due to deltametrics.cube

### DIFF
--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -11,7 +11,6 @@ import abc
 import warnings
 
 from deltametrics.utils import is_ndarray_or_xarray
-from . import cube
 from . import plan
 from deltametrics.plot import append_colorbar
 
@@ -32,6 +31,8 @@ class BaseMask(abc.ABC):
 
         *args
         """
+        from deltametrics.cube import BaseCube
+
         # add mask type as attribute
         self._mask_type = mask_type
         self._shape = None
@@ -53,7 +54,7 @@ class BaseMask(abc.ABC):
                 return
             else:
                 raise ValueError("Expected 1 input, got 0.")
-        elif (len(args) == 1) and issubclass(type(args[0]), cube.BaseCube):
+        elif (len(args) == 1) and issubclass(type(args[0]), BaseCube):
             self._input_flag = "cube"
             # take a slice to have the coordinates available
             #   note: this is an uncessary disk-read operation, which

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -8,7 +8,6 @@ import xarray as xr
 import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 
-from . import cube
 from . import mask
 from . import plan
 from deltametrics.utils import NoStratigraphyError
@@ -219,7 +218,9 @@ class BaseSection(abc.ABC):
 
     def connect(self, InputInstance, name=None):
         """Connect this Section instance to a Cube instance."""
-        if issubclass(type(InputInstance), cube.BaseCube):
+        from deltametrics.cube import BaseCube
+
+        if issubclass(type(InputInstance), BaseCube):
             self._underlying = InputInstance
             self._underlying_type = "cube"
             self._variables = InputInstance.variables
@@ -430,8 +431,11 @@ class BaseSection(abc.ABC):
             The underlying data returned as an xarray `DataArray`, maintaining
             coordinates.
         """
+        from deltametrics.cube import DataCube
+        from deltametrics.cube import StratigraphyCube
+
         if self._underlying_type == "cube":
-            if isinstance(self._underlying, cube.DataCube):
+            if isinstance(self._underlying, DataCube):
                 _xrDA = xr.DataArray(
                     self._underlying[var].data[:, self._dim1_idx, self._dim2_idx],
                     coords={"s": self._s, self._z.dims[0]: self._z},
@@ -453,7 +457,7 @@ class BaseSection(abc.ABC):
                         ),
                     )
                 return _xrDA
-            elif isinstance(self._underlying, cube.StratigraphyCube):
+            elif isinstance(self._underlying, StratigraphyCube):
                 _xrDA = xr.DataArray(
                     self._underlying[var].data[:, self._dim1_idx, self._dim2_idx],
                     coords={"s": self._s, self._z.dims[0]: self._z},
@@ -599,6 +603,7 @@ class BaseSection(abc.ABC):
 
         .. plot:: section/section_demo_quick_strat.py
         """
+        from deltametrics.cube import BaseCube
         from deltametrics.plot import VariableSet
         from deltametrics.plot import append_colorbar
         from deltametrics.plot import get_display_arrays
@@ -629,7 +634,7 @@ class BaseSection(abc.ABC):
             # if te underlying is a cube
             _varinfo = (
                 self._underlying.varset[SectionAttribute]
-                if issubclass(type(self._underlying), cube.BaseCube)
+                if issubclass(type(self._underlying), BaseCube)
                 else VariableSet()[SectionAttribute]
             )
             # main routines for plot styles


### PR DESCRIPTION
This pull request fixes some circular imports that involve the *deltametrics.cube* module. The fix that I've implemented here is to simply move some of the imports into the methods where they are used. A better solution may be to reorganize the package or to embrace duck typing instead of checking for object types within methods. Either way, that sounds like a separate pull request.

ref: #146