### PR TITLE
Remove get version function

### DIFF
--- a/deltametrics/__init__.py
+++ b/deltametrics/__init__.py
@@ -6,5 +6,4 @@ from . import section
 from . import strat
 from . import utils
 from . import sample_data
-
-__version__ = utils._get_version()
+from ._version import __version__

--- a/deltametrics/_version.py
+++ b/deltametrics/_version.py
@@ -1,5 +1,1 @@
-def __version__():
-    """
-    Private version declaration, gets assigned to dm.__version__ during import
-    """
-    return "0.4.3"
+__version__ = "0.4.3"

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -7,12 +7,9 @@ import numpy as np
 import netCDF4
 import pooch
 
+from deltametrics._version import __version__
 from deltametrics.cube import DataCube
 from deltametrics.utils import _get_version
-
-
-# deltametrics version
-__version__ = _get_version()
 
 # enusre DeprecationWarning is shown
 warnings.simplefilter("default")

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -9,7 +9,6 @@ import pooch
 
 from deltametrics._version import __version__
 from deltametrics.cube import DataCube
-from deltametrics.utils import _get_version
 
 # enusre DeprecationWarning is shown
 warnings.simplefilter("default")

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -7,14 +7,6 @@ import datetime
 from numba import njit
 
 
-def _get_version():
-    """
-    Extract version number from single file, and make it availabe everywhere.
-    """
-    from . import _version
-    return _version.__version__()
-
-
 def format_number(number):
     integer = int(round(number, -1))
     string = "{:,}".format(integer)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,18 +10,32 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+import importlib
 import os
 import sys
 
-import pyvista
 
-from deltametrics._version import __version__
+def get_version_from_file(path_to_version_file: str) -> str:
+    spec = importlib.util.spec_from_file_location("_version", path_to_version_file)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    return module.__version__
+
+
+src_dir = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
+)
 
 # -- Project information -----------------------------------------------------
 
 project = 'DeltaMetrics'
 copyright = '2020, The DeltaRCM Team'
 author = 'The DeltaRCM Team'
+
+__version__ = get_version_from_file(
+    os.path.join(src_dir, "deltametrics", "_version.py")
+)
 
 # The full version, including alpha/beta/rc tags
 release = __version__

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,7 +15,7 @@ import sys
 
 import pyvista
 
-import deltametrics as dm
+from deltametrics._version import __version__
 
 # -- Project information -----------------------------------------------------
 
@@ -24,8 +24,8 @@ copyright = '2020, The DeltaRCM Team'
 author = 'The DeltaRCM Team'
 
 # The full version, including alpha/beta/rc tags
-release = dm.__version__
-version = dm.__version__
+release = __version__
+version = __version__
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/reference/utils/index.rst
+++ b/docs/source/reference/utils/index.rst
@@ -18,7 +18,6 @@ Utility functions
 .. autofunction:: coordinates_to_segments
 .. autofunction:: line_to_cells
 .. autofunction:: _walk_line
-.. autofunction:: _get_version
 
 
 Utility Exceptions and Warnings

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 #! /usr/bin/env python
 from setuptools import setup, find_packages
 
-from deltametrics import utils
+from deltametrics._version import __version__
 
 setup(
     name="DeltaMetrics",
-    version=utils._get_version(),
+    version=__version__,
     author="The DeltaRCM Team",
     license="MIT",
     description="Tools for manipulating sedimentologic data cubes.",


### PR DESCRIPTION
This pull request remove the `_get_version` function in `_version.py` and, instead, simply sets `__version__` directly as a string. This will make things a little easier when moving from *setup.py* to *pyproject.toml*.