### PR TITLE
Convert docstring `plot` directives to doctests

### DIFF
--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -2658,11 +2658,9 @@ class DepositMask(BaseMask):
 
         This is a straightforward mask, simply checking where the
         `elevation` is greater than the `background_value`, outside
-        some tolerance:
+        some tolerance::
 
-        .. code::
-
-            np.abs(elevation - background_value) > elevation_tolerance   # noqa: E501
+            np.abs(elevation - background_value) > elevation_tolerance
 
         However, using the mask provides benefits of array tracking and
         various integrations with other masks and functions.

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1128,9 +1128,7 @@ def compute_land_area(land_mask):
 
         In implementation, this is a simple 1-liner summation over the mask.
         It is implemented as a function here for convenience and consistency
-        in the api.
-
-        .. code::
+        in the api::
 
             land_area = np.sum(land_mask.integer_mask) * dx * dx
 

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -640,9 +640,8 @@ def vintage_colormap(H_SL=0.0, h=4.5, n=1.0):
     >>> cb1 = append_colorbar(im1, ax[1])
     >>> plt.tight_layout()
 
-    To use the colormap exactly as described in Pearson's original publication, use parameters
-
-    .. code::
+    To use the colormap exactly as described in Pearson's original publication,
+    use parameters::
 
         cmap, norm = vintage_colormap(H_SL=0, h=20, n=10)
 

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -1122,8 +1122,18 @@ def show_one_dimensional_trajectory_to_strata(
     For example, we can quickly visualize the processing of a 1D timeseries of
     bed elevations into boxy stratigraphy with this routine.
 
-    .. plot:: guides/userguide_1d_example.py
-        :include-source:
+    .. plot::
+
+        >>> import matplotlib.pyplot as plt
+        >>> from deltametrics.plot import show_one_dimensional_trajectory_to_strata
+        >>> from deltametrics.sample_data import golf
+
+        >>> golfcube = golf()
+
+        >>> ets = golfcube['eta'].data[:, 10, 85]  # a "real" slice of the model
+
+        >>> fig, ax = plt.subplots(figsize=(8, 4))
+        >>> show_one_dimensional_trajectory_to_strata(ets, ax=ax, dz=0.25)
 
     The orange line depicts the resultant stratigraphy, with all
     bed-elevations above this line cut from the stratigraphy by the

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -579,8 +579,6 @@ class BaseSection(abc.ABC):
             ...     'demo', StrikeSection(distance_idx=5))
             >>> golfcube.sections['demo'].show('velocity')
 
-            .. plot:: section/section_demo_spacetime.py
-
             Note that the last line above is functionally equivalent to
             ``golfcube.show_section('demo', 'velocity')``.
 
@@ -602,8 +600,6 @@ class BaseSection(abc.ABC):
             ...                                ax=ax[2], label='quick stratigraphy')
             >>> golfcube.sections['demo'].show('depth', style='lines', data='stratigraphy',
             ...                                ax=ax[3], label='quick stratigraphy')          # noqa: E501
-
-        .. plot:: section/section_demo_quick_strat.py
         """
         from deltametrics.cube import BaseCube
         from deltametrics.plot import VariableSet

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -97,7 +97,8 @@ doctest_test_doctest_blocks = ''
 
 # mpl plots
 plot_basedir = 'pyplots'
-plot_html_show_source_link = False
+plot_html_show_source_link = True
+plot_include_source = True
 plot_formats = ['png', ('hires.png', 300)]
 plot_pre_code = '''
 import numpy as np

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,14 +96,7 @@ relative_files = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = [
-    "deltametrics/cube.py",
-    "deltametrics/mask.py",
-    "deltametrics/mobility.py",
-    "deltametrics/plan.py",
-    "deltametrics/plot.py",
-    "deltametrics/section.py",
-    "deltametrics/strat.py",
-    "deltametrics/utils.py",
+    "deltametrics",
     "tests",
 ]
 norecursedirs = [


### PR DESCRIPTION
It would be nice if the code contained within the *sphinx* `plot` directives that are in *docstrings* could be run as *doctests*. There are a several things preventing this from happening:
* Some of the code is not preceded by `>>>`
* Some (all?) of the blocks conclude with call to `plt.show`, which causes windows to pop when the tests are run
* *pytest* doesn't execute the `plot_pre_code`, which causes the *doctests* to fail
* The `plot` blocks don't contain expected output after each command, which causes the *doctests* to fail

These blocks are currently run—but only these blocks, not regular doctests—when the docs are built but only as smoke tests.

This pull request will be a base pr that I'll break into small, more manageable. prs.