### PR TITLE
Add a nox file to automate routine maintenance tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,12 +33,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install pytest pytest-cov coveralls
-        pip install -r requirements.txt
+        pip install nox
     - name: Test with pytest
       run: |
-        python -m pytest --cov=deltametrics/ --cov-report=xml
+        nox -s coverage
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v5
       with:
@@ -61,14 +59,11 @@ jobs:
         python-version: '3.12'
     - name: Install dependencies
       run: |
-        pip install -r requirements-docs.txt
+        pip install nox
         sudo apt update -y && sudo apt install -y latexmk texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended dvipng ffmpeg
-    - name: Install DeltaMetrics
-      run: |
-        pip install .
     - name: Build and test documentation
       run: |
-        (cd docs && make docs)
+        nox -s docs
     - name: Debug
       run: |
         echo $REF

--- a/docs/source/guides/examples/plot/simple_movie.rst
+++ b/docs/source/guides/examples/plot/simple_movie.rst
@@ -34,6 +34,10 @@ Then, make the animation with matplotlib's `FuncAnimation`.
     :context:
     :nofigs:
 
+    import os
+
+    os.makedirs("../../../../build/plot_directive/guides/examples/plot/", exist_ok=True)
+
     anim = animation.FuncAnimation(
         fig, update_field,
         frames=golf.shape[0]-1,

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import os
+
+import nox
+
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+
+
+@nox.session
+def build(session: nox.Session) -> None:
+    """Build sdist and wheel dists."""
+    session.install("pip", "build")
+    session.install("setuptools")
+    session.run("python", "--version")
+    session.run("pip", "--version")
+    session.run("python", "-m", "build")
+
+
+@nox.session
+def install(session: nox.Session) -> None:
+    """install the package"""
+    first_arg = session.posargs[0] if session.posargs else None
+
+    if first_arg and not os.path.isfile(first_arg):
+        session.error("path must be a source distribution file")
+    session.install(first_arg or ".")
+
+
+@nox.session
+def test(session: nox.Session) -> None:
+    """Run the tests."""
+    session.install("pytest", "requirements.txt")
+    install(session)
+
+    session.run("pytest", "-vvv")
+
+
+@nox.session
+def coverage(session: nox.Session) -> None:
+    """Run coverage"""
+    session.install("coverage", "pytest", "-r", "requirements.txt")
+    install(session)
+
+    session.run(
+        "coverage", "run", "-m", "pytest", "-vvv", env={"COVERAGE_CORE": "sysmon"}
+    )
+
+    if "CI" in os.environ:
+        session.run("coverage", "xml", "-o", os.path.join(ROOT, "coverage.xml"))
+    else:
+        session.run("coverage", "report", "--ignore-errors", "--show-missing")
+
+
+@nox.session
+def lint(session: nox.Session) -> None:
+    """Look for lint."""
+    session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files")
+
+
+@nox.session
+def docs(session: nox.Session) -> None:
+    """Build the docs."""
+    session.install("-r", "requirements-docs.txt")
+    install(session)
+
+    os.makedirs("docs/build", exist_ok=True)
+    session.run(
+        "sphinx-build",
+        *("-b", "html"),
+        "-W",
+        "--keep-going",
+        "docs/source",
+        "docs/build/html",
+    )
+    session.log("generated docs at build/html")


### PR DESCRIPTION
This pull request adds a [nox](https://nox.thea.codes/) file, `noxfile.py`, that can be used to automate some routine maintenance tasks. For example, running the tests, running the linters, and building the docs. I've also modified the GitHub Actions workflows to use *nox* so that workflow jobs are run in the same way as you would run them locally.

Once *nox* is installed,
```
pip install nox
```
you can run various sessions with the `-s` option,
```
nox -s test  # run the tests
nox -s docs  # build the docs
nox -s lint  # run the linters
```
Note that the *lint* session doesn't work yet. I'll add linters in another pull request.
