### PR TITLE
Add linters to deltametrics: sort imports

### DIFF
--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -1,27 +1,26 @@
-import os
-import copy
 import abc
+import copy
+import os
 import warnings
 
+import matplotlib.pyplot as plt
 import numpy as np
 import xarray as xr
-
-import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 unused import
 
+from deltametrics.io import DictionaryIO
+from deltametrics.io import NetCDFIO
 from deltametrics.plan import BasePlanform
 from deltametrics.plan import Planform
+from deltametrics.plot import VariableSet
 from deltametrics.section import BaseSection
 from deltametrics.section import DipSection
 from deltametrics.section import StrikeSection
 from deltametrics.strat import _adjust_elevation_by_subsidence
 from deltametrics.strat import _determine_strat_coordinates
 from deltametrics.strat import BoxyStratigraphyAttributes
-from deltametrics.strat import MeshStratigraphyAttributes
 from deltametrics.strat import compute_boxy_stratigraphy_coordinates
-from deltametrics.plot import VariableSet
-from deltametrics.io import DictionaryIO
-from deltametrics.io import NetCDFIO
+from deltametrics.strat import MeshStratigraphyAttributes
 
 
 class BaseCube(abc.ABC):

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -1,11 +1,11 @@
 import abc
-import os
 import copy
+import os
 import warnings
 
-import xarray as xr
-import numpy as np
 import netCDF4
+import numpy as np
+import xarray as xr
 
 
 class BaseIO(abc.ABC):

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -1,17 +1,17 @@
 """Classes and methods to create masks of planform features and attributes."""
-import numpy as np
-import xarray as xr
-import matplotlib.pyplot as plt
-from skimage import feature
-from skimage import morphology
-from skimage import measure
-from scipy.ndimage import binary_fill_holes
-
 import abc
 import warnings
 
-from deltametrics.utils import is_ndarray_or_xarray
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from scipy.ndimage import binary_fill_holes
+from skimage import feature
+from skimage import measure
+from skimage import morphology
+
 from deltametrics.plot import append_colorbar
+from deltametrics.utils import is_ndarray_or_xarray
 
 
 class BaseMask(abc.ABC):

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -16,10 +16,10 @@ functions, allowing for decay constants and timescales to be quantified.
 .. [Jarriel et al 2019] Jarriel, Teresa, Leo F. Isikdogan, Alan Bovik, and Paola Passalacqua. "Characterization of deltaic channel morphodynamics from imagery time series using the channelized response variance." Journal of Geophysical Research: Earth Surface 124, no. 12 (2019): 3022-3042.
 
 """
-
 import numpy as np
-from deltametrics import mask
 import xarray as xr
+
+from deltametrics import mask
 
 
 def check_inputs(chmap, basevalues=None, basevalues_idx=None, window=None,

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1,31 +1,30 @@
-import numpy as np
-import xarray as xr
-import matplotlib.pyplot as plt
-
-from scipy.spatial import ConvexHull
-from scipy.signal import fftconvolve
-
-# from shapely.geometry.polygon import Polygon
-from scipy.ndimage import binary_fill_holes, generate_binary_structure
-
-from skimage import morphology
-
 import abc
 import warnings
 
-from numba import njit, prange, set_num_threads
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
+from numba import njit
+from numba import prange
+from numba import set_num_threads
+from scipy.ndimage import binary_fill_holes
+from scipy.ndimage import generate_binary_structure
+from scipy.signal import fftconvolve
+from scipy.spatial import ConvexHull
+from skimage import morphology
 
 from deltametrics.mask import BaseMask
 from deltametrics.mask import ChannelMask
 from deltametrics.mask import ElevationMask
 from deltametrics.mask import LandMask
 from deltametrics.mask import ShorelineMask
-from deltametrics.section import BaseSection
+from deltametrics.plot import append_colorbar
 from deltametrics.plot import VariableInfo
 from deltametrics.plot import VariableSet
-from deltametrics.plot import append_colorbar
+from deltametrics.section import BaseSection
 from deltametrics.utils import _points_in_polygon
 from deltametrics.utils import is_ndarray_or_xarray
+# from shapely.geometry.polygon import Polygon
 
 class BasePlanform(abc.ABC):
     """Base planform object.

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -1,15 +1,14 @@
-import numpy as np
-import xarray as xr
-
 import colorsys
 
 import matplotlib as mpl
-import matplotlib.pyplot as plt
-import matplotlib.ticker as ticker
+import matplotlib.collections as coll
 import matplotlib.colors as colors
 import matplotlib.patches as ptch
-import matplotlib.collections as coll
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
 import mpl_toolkits.axes_grid1 as axtk
+import numpy as np
+import xarray as xr
 
 from deltametrics.strat import _adjust_elevation_by_subsidence
 from deltametrics.strat import _compute_elevation_to_preservation

--- a/deltametrics/sample_data/sample_data.py
+++ b/deltametrics/sample_data/sample_data.py
@@ -1,9 +1,9 @@
-import sys
 import os
+import sys
 import warnings
 
-import numpy as np
 import netCDF4
+import numpy as np
 import pooch
 
 if sys.version_info >= (3, 12):  # pragma: no cover (PY12+)

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -1,19 +1,18 @@
 import abc
 import warnings
 
-import numpy as np
-from scipy import sparse
-import xarray as xr
-
 import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
 from matplotlib.collections import LineCollection
+from scipy import sparse
 
-from deltametrics.utils import NoStratigraphyError
 from deltametrics.utils import circle_to_cells
 from deltametrics.utils import coordinates_to_segments
 from deltametrics.utils import guess_land_width_from_land
 from deltametrics.utils import is_ndarray_or_xarray
 from deltametrics.utils import line_to_cells
+from deltametrics.utils import NoStratigraphyError
 from deltametrics.utils import segments_to_cells
 
 

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -1,10 +1,10 @@
+import datetime
+import time
+
 import numpy as np
 import xarray as xr
-from scipy import optimize
-import time
-import datetime
-
 from numba import njit
+from scipy import optimize
 
 
 def format_number(number):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,9 +3,7 @@
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
-
 # -- Path setup --------------------------------------------------------------
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/docs/source/pyplots/examples/preserved_velocities.py
+++ b/docs/source/pyplots/examples/preserved_velocities.py
@@ -1,6 +1,7 @@
-import numpy as np
-import deltametrics as dm
 import matplotlib.pyplot as plt
+import numpy as np
+
+import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta')

--- a/docs/source/pyplots/guides/10min_all_sections_strat.py
+++ b/docs/source/pyplots/guides/10min_all_sections_strat.py
@@ -1,5 +1,6 @@
-import deltametrics as dm
 import matplotlib.pyplot as plt
+
+import deltametrics as dm
 
 golfcube = dm.sample_data.golf()
 golfcube.stratigraphy_from('eta', dz=0.05)

--- a/docs/source/pyplots/guides/cover.py
+++ b/docs/source/pyplots/guides/cover.py
@@ -1,5 +1,6 @@
-import deltametrics as dm
 import matplotlib.pyplot as plt
+
+import deltametrics as dm
 
 
 golfcube = dm.sample_data.golf()

--- a/docs/source/pyplots/mask/centerlinemask.py
+++ b/docs/source/pyplots/mask/centerlinemask.py
@@ -1,7 +1,7 @@
 """Visual for CenterlineMask."""
 import deltametrics as dm
-from deltametrics.mask import ChannelMask
 from deltametrics.mask import CenterlineMask
+from deltametrics.mask import ChannelMask
 
 golfcube = dm.sample_data.golf()
 channel_mask = ChannelMask(golfcube['velocity'].data[-1, :, :],

--- a/docs/source/pyplots/plot/document_variableset.py
+++ b/docs/source/pyplots/plot/document_variableset.py
@@ -1,7 +1,6 @@
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
-
-import matplotlib as mpl
 
 import deltametrics as dm
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,6 +57,7 @@ def coverage(session: nox.Session) -> None:
 def lint(session: nox.Session) -> None:
     """Look for lint."""
     session.install("pre-commit")
+    session.run("pre-commit", "run", "--all-files", "reorder-python-imports")
 
 
 @nox.session

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -1,22 +1,21 @@
-import pytest
 import re
 import unittest.mock as mock
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from deltametrics.cube import DataCube
 from deltametrics.cube import StratigraphyCube
-
-from deltametrics.plot import VariableSet
-from deltametrics.section import BaseSection
-from deltametrics.section import StrikeSection
 from deltametrics.plan import BasePlanform
 from deltametrics.plan import Planform
-from deltametrics.utils import NoStratigraphyError
+from deltametrics.plot import VariableSet
 from deltametrics.sample_data.sample_data import _get_golf_path
 from deltametrics.sample_data.sample_data import _get_landsat_path
 from deltametrics.sample_data.sample_data import _get_rcm8_path
+from deltametrics.section import BaseSection
+from deltametrics.section import StrikeSection
+from deltametrics.utils import NoStratigraphyError
 
 
 rcm8_path = _get_rcm8_path()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,17 +1,16 @@
-import pytest
-
-import sys
 import os
+import sys
 
 import numpy as np
+import pytest
+import utilities
 import xarray as xr
 
 from deltametrics.io import DictionaryIO
 from deltametrics.io import NetCDFIO
-from deltametrics.sample_data.sample_data import _get_rcm8_path
 from deltametrics.sample_data.sample_data import _get_golf_path
 from deltametrics.sample_data.sample_data import _get_landsat_path
-import utilities
+from deltametrics.sample_data.sample_data import _get_rcm8_path
 
 
 rcm8_path = _get_rcm8_path()

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,12 +1,12 @@
 """Tests for the mask.py script."""
-import pytest
-import sys
 import os
-import numpy as np
-import xarray as xr
-import matplotlib.pyplot as plt
-
+import sys
 import unittest.mock as mock
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
 
 from deltametrics.cube import DataCube
 from deltametrics.mask import BaseMask
@@ -20,7 +20,8 @@ from deltametrics.mask import GeometricMask
 from deltametrics.mask import LandMask
 from deltametrics.mask import ShorelineMask
 from deltametrics.mask import WetMask
-from deltametrics.plan import OpeningAnglePlanform, MorphologicalPlanform
+from deltametrics.plan import MorphologicalPlanform
+from deltametrics.plan import OpeningAnglePlanform
 from deltametrics.sample_data.sample_data import _get_golf_path
 from deltametrics.sample_data.sample_data import _get_rcm8_path
 

--- a/tests/test_mobility.py
+++ b/tests/test_mobility.py
@@ -1,12 +1,12 @@
 """Tests for mobility.py."""
-import pytest
-import sys
 import os
+import sys
+
 import numpy as np
+import pytest
 import xarray as xr
 
 from deltametrics.cube import DataCube
-from deltametrics.sample_data.sample_data import _get_rcm8_path
 from deltametrics.mask import ChannelMask
 from deltametrics.mask import LandMask
 from deltametrics.mobility import _calculate_temporal_linear_slope
@@ -17,6 +17,7 @@ from deltametrics.mobility import calculate_planform_overlap
 from deltametrics.mobility import calculate_reworking_fraction
 from deltametrics.mobility import channel_presence
 from deltametrics.mobility import check_inputs
+from deltametrics.sample_data.sample_data import _get_rcm8_path
 
 
 rcm8_path = _get_rcm8_path()

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,23 +1,17 @@
-import pytest
 import unittest.mock as mock
 
-import numpy as np
-import xarray as xr
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
 
-from deltametrics.sample_data.sample_data import _get_golf_path
-from deltametrics.sample_data.sample_data import _get_rcm8_path
-
+from deltametrics.cube import DataCube
+from deltametrics.cube import StratigraphyCube
 from deltametrics.mask import ChannelMask
 from deltametrics.mask import ElevationMask
 from deltametrics.mask import LandMask
 from deltametrics.mask import ShorelineMask
-from deltametrics.cube import DataCube
-from deltametrics.cube import StratigraphyCube
 from deltametrics.plan import _get_channel_starts_and_ends
-from deltametrics.plan import MorphologicalPlanform
-from deltametrics.plan import OpeningAnglePlanform
-from deltametrics.plan import Planform
 from deltametrics.plan import compute_channel_depth
 from deltametrics.plan import compute_channel_width
 from deltametrics.plan import compute_land_area
@@ -26,7 +20,12 @@ from deltametrics.plan import compute_shoreline_length
 from deltametrics.plan import compute_shoreline_roughness
 from deltametrics.plan import compute_surface_deposit_age
 from deltametrics.plan import compute_surface_deposit_time
+from deltametrics.plan import MorphologicalPlanform
+from deltametrics.plan import OpeningAnglePlanform
+from deltametrics.plan import Planform
 from deltametrics.plan import shaw_opening_angle_method
+from deltametrics.sample_data.sample_data import _get_golf_path
+from deltametrics.sample_data.sample_data import _get_rcm8_path
 from deltametrics.section import CircularSection
 
 # a simple custom layout

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,30 +1,30 @@
-import pytest
 import os
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
 
-from deltametrics.plot import VariableInfo
-from deltametrics.plot import VariableSet
+from deltametrics.cube import DataCube
+from deltametrics.cube import StratigraphyCube
 from deltametrics.plot import _fill_steps
 from deltametrics.plot import _scale_lightness
 from deltametrics.plot import aerial_view
 from deltametrics.plot import append_colorbar
 from deltametrics.plot import cartographic_colormap
 from deltametrics.plot import get_display_arrays
-from deltametrics.plot import get_display_lines
 from deltametrics.plot import get_display_limits
+from deltametrics.plot import get_display_lines
 from deltametrics.plot import overlay_sparse_array
 from deltametrics.plot import show_histograms
 from deltametrics.plot import show_one_dimensional_trajectory_to_strata
 from deltametrics.plot import style_axes_km
+from deltametrics.plot import VariableInfo
+from deltametrics.plot import VariableSet
 from deltametrics.plot import vintage_colormap
-from deltametrics.cube import DataCube
-from deltametrics.cube import StratigraphyCube
+from deltametrics.sample_data.sample_data import _get_golf_path
 from deltametrics.section import StrikeSection
 from deltametrics.utils import NoStratigraphyError
-from deltametrics.sample_data.sample_data import _get_golf_path
 
 
 golf_path = _get_golf_path()

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -1,22 +1,20 @@
-import pytest
-
-import numpy as np
-import xarray as xr
 import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+import xarray as xr
 
 from deltametrics.cube import DataCube
 from deltametrics.cube import StratigraphyCube
 from deltametrics.mask import ElevationMask
 from deltametrics.plan import Planform
-
+from deltametrics.sample_data.sample_data import _get_golf_path
+from deltametrics.sample_data.sample_data import _get_rcm8_path
 from deltametrics.section import CircularSection
 from deltametrics.section import DipSection
 from deltametrics.section import PathSection
 from deltametrics.section import RadialSection
 from deltametrics.section import StrikeSection
 from deltametrics.utils import NoStratigraphyError
-from deltametrics.sample_data.sample_data import _get_golf_path
-from deltametrics.sample_data.sample_data import _get_rcm8_path
 
 
 rcm8_path = _get_rcm8_path()

--- a/tests/test_strat.py
+++ b/tests/test_strat.py
@@ -1,11 +1,11 @@
 """Tests for the mask.py script."""
-import pytest
-
 import numpy as np
+import pytest
 import xarray as xr
 
 from deltametrics.cube import DataCube
 from deltametrics.cube import StratigraphyCube
+from deltametrics.sample_data.sample_data import _get_golf_path
 from deltametrics.strat import _adjust_elevation_by_subsidence
 from deltametrics.strat import _compute_elevation_to_preservation
 from deltametrics.strat import _compute_preservation_to_cube
@@ -15,7 +15,6 @@ from deltametrics.strat import compute_boxy_stratigraphy_volume
 from deltametrics.strat import compute_net_to_gross
 from deltametrics.strat import compute_sedimentograph
 from deltametrics.strat import compute_thickness_surfaces
-from deltametrics.sample_data.sample_data import _get_golf_path
 
 
 golf_path = _get_golf_path()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,19 @@
-import pytest
-
-import os
-import time
 import glob
+import os
 import pathlib
+import time
 
 import numpy as np
+import pytest
 
-from deltametrics.utils import NoStratigraphyError
-from deltametrics.utils import curve_fit
-from deltametrics.utils import format_table
-from deltametrics.utils import format_number
-from deltametrics.utils import line_to_cells
-from deltametrics.utils import runtime_from_log
 from deltametrics.mobility import calculate_channel_abandonment
 from deltametrics.sample_data.sample_data import _get_golf_path
+from deltametrics.utils import curve_fit
+from deltametrics.utils import format_number
+from deltametrics.utils import format_table
+from deltametrics.utils import line_to_cells
+from deltametrics.utils import NoStratigraphyError
+from deltametrics.utils import runtime_from_log
 
 class TestNoStratigraphyError:
 


### PR DESCRIPTION
This pull request adds a linter that sorts import statements. The main purpose of this linter is to reduce the number of merge conflicts based on imports.

* Sorts imports alphabetically
* Splits imports into third party, first party, and standard python library imports
* Removes duplicates
* One import per line