### PR TITLE
Set up pre-commit for managing the linters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,23 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
 
+  lint:
+    runs-on: "ubuntu-latest"
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+    - name: Install nox
+      run: pip install nox
+    - name: Run the linters
+      run: nox -s lint
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,66 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 24.10.0
+  hooks:
+  - id: black
+    name: black
+    description: "Black: The uncompromising Python code formatter"
+    entry: black
+    language: python
+    language_version: python3
+    minimum_pre_commit_version: 2.9.2
+    require_serial: true
+    types_or: [python, pyi]
+    exclude: .*
+
+- repo: https://github.com/keewis/blackdoc
+  rev: v0.3.9
+  hooks:
+  - id: blackdoc
+    description: "Black for doctests"
+    additional_dependencies: ["black==24.10.0"]
+    exclude: .*
+  - id: blackdoc-autoupdate-black
+
+- repo: https://github.com/pycqa/flake8
+  rev: 7.1.1
+  hooks:
+  - id: flake8
+    additional_dependencies:
+    - flake8-bugbear
+    - flake8-comprehensions
+    - flake8-simplify
+    exclude: ^docs/source/pyplots/guides/.*$
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v3.19.0
+  hooks:
+  - id: pyupgrade
+    args: [--py311-plus]
+
+- repo: https://github.com/asottile/reorder-python-imports
+  rev: v3.14.0
+  hooks:
+  - id: reorder-python-imports
+    args: [--py311-plus]
+
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v5.0.0
+  hooks:
+    - id: check-builtin-literals
+    - id: check-added-large-files
+    - id: check-case-conflict
+    - id: check-toml
+    - id: check-yaml
+    - id: debug-statements
+    - id: end-of-file-fixer
+    - id: forbid-new-submodules
+    - id: mixed-line-ending
+    - id: trailing-whitespace
+    - id: name-tests-test
+    - id: file-contents-sorter
+      files: |
+        (?x)^(
+          .*requirements(-\w+)?.(in|txt)|
+          requirements/.*\.txt
+        )

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,6 @@ def coverage(session: nox.Session) -> None:
 def lint(session: nox.Session) -> None:
     """Look for lint."""
     session.install("pre-commit")
-    session.run("pre-commit", "run", "--all-files")
 
 
 @nox.session


### PR DESCRIPTION
This pull request adds a *pre-commit* config file that holds the linters for *deltametrics*, and adds a new job, *lint*, to the GitHub Actions workflow. The *lint* *nox* session doesn't run any of the *pre-commit* hooks, I'll add that in separate pull requests.