### PR TITLE
Add linters to deltametrics: flake8-comprehensions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,10 @@ repos:
   rev: 7.1.1
   hooks:
   - id: flake8
-    # additional_dependencies:
+    additional_dependencies:
     # - flake8-bugbear
-    # - flake8-comprehensions
-    # - flake8-simplify
+    - flake8-comprehensions
+    - flake8-simplify
     exclude: ^docs/source/pyplots/guides/.*$
 
 - repo: https://github.com/asottile/pyupgrade

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -330,7 +330,7 @@ class NetCDFIO(FileIO):
     @property
     def keys(self):
         """Variable names in file."""
-        return [var for var in self.dataset.variables]
+        return list(self.dataset.variables)
 
 
 class DictionaryIO(BaseIO):
@@ -364,7 +364,7 @@ class DictionaryIO(BaseIO):
         These variables are pulled from the loaded dataset.
         """
         _vars = self.dataset.keys()
-        self.known_variables = [item for item in _vars]
+        self.known_variables = list(_vars)
 
     def get_known_coords(self, dimensions):
         """List known coordinates.
@@ -462,4 +462,4 @@ class DictionaryIO(BaseIO):
     @property
     def keys(self):
         """Variable names in file."""
-        return [var for var in self.dataset.variables]
+        return list(self.dataset.variables)

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -1594,12 +1594,10 @@ class ShorelineMask(BaseMask):
         # breakpoint()
 
         # convert contour to the shoreline mask itself
-        flat_inds = list(
-            map(
-                lambda x: np.ravel_multi_index(x, shoremap.shape),
-                np.round(C).astype(int),
-            )
-        )
+        flat_inds = [
+            np.ravel_multi_index(x, shoremap.shape)
+            for x in np.round(C).astype(int)
+        ]
         shoremap.flat[flat_inds] = 1
 
         self._contour = C

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -117,7 +117,7 @@ class AttributeChecker:
             else:
                 att_dict[check] = True
 
-        log_list = [value for value in att_dict.values()]
+        log_list = list(att_dict.values())
         log_form = [value for string, value in
                     zip(log_list, att_dict.keys()) if not string]
         if not all(log_list):

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1707,7 +1707,7 @@ class TestGeometricMask:
         gmsk.circular(1)
         assert gmsk._mask[0, 2] == 0
 
-        gmsk2 = GeometricMask(arr, circular=dict(rad1=1))
+        gmsk2 = GeometricMask(arr, circular={"rad1": 1})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_circular_2radii(self):
@@ -1720,7 +1720,7 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[:, 0] == 0)
         assert np.all(gmsk._mask[-1, :] == 0)
 
-        gmsk2 = GeometricMask(arr, circular=dict(rad1=1, rad2=2))
+        gmsk2 = GeometricMask(arr, circular={"rad1": 1, "rad2": 2})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_circular_custom_origin(self):
@@ -1750,7 +1750,7 @@ class TestGeometricMask:
         assert gmsk.xc == 0
         assert gmsk.yc == 3
 
-        gmsk2 = GeometricMask(arr, circular=dict(rad1=1, rad2=2, origin=(3, 3)))
+        gmsk2 = GeometricMask(arr, circular={"rad1": 1, "rad2": 2, "origin": (3, 3)})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_strike_one(self):
@@ -1761,7 +1761,7 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[:2, :] == 0)
         assert np.all(gmsk._mask[2:, :] == 1)
 
-        gmsk2 = GeometricMask(arr, strike=dict(ind1=2))
+        gmsk2 = GeometricMask(arr, strike={"ind1": 2})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_strike_two(self):
@@ -1773,7 +1773,7 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[2:4, :] == 1)
         assert np.all(gmsk._mask[4:, :] == 0)
 
-        gmsk2 = GeometricMask(arr, strike=dict(ind1=2, ind2=4))
+        gmsk2 = GeometricMask(arr, strike={"ind1": 2, "ind2": 4})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_dip_one(self):
@@ -1785,7 +1785,7 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[:, 0] == 0)
         assert np.all(gmsk._mask[:, -1] == 0)
 
-        gmsk2 = GeometricMask(arr, dip=dict(ind1=5))
+        gmsk2 = GeometricMask(arr, dip={"ind1": 5})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_dip_two(self):
@@ -1797,7 +1797,7 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[:, 2:4] == 1)
         assert np.all(gmsk._mask[:, 4:] == 0)
 
-        gmsk2 = GeometricMask(arr, dip=dict(ind1=2, ind2=4))
+        gmsk2 = GeometricMask(arr, dip={"ind1": 2, "ind2": 4})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_angular_half(self):
@@ -1811,7 +1811,7 @@ class TestGeometricMask:
         assert np.all(gmsk._mask[:, :101] == 1)
         assert np.all(gmsk._mask[:, 101:] == 0)
 
-        gmsk2 = GeometricMask(arr, angular=dict(theta1=theta1, theta2=theta2))
+        gmsk2 = GeometricMask(arr, angular={"theta1": theta1, "theta2": theta2})
         assert np.all(gmsk2.mask == gmsk.mask)
 
     def test_angular_bad_dims(self):


### PR DESCRIPTION
Adds the flake8-comprehensions linter to deltametrics and fixes some issues. Mostly this is stuff like using:
* `list(vars)` instead of `[var for var in vars]`. The list comprehension is unnecessary.
* `{"foo": 1}` instead of `dict(foo=1)` (). This probably doesn't make much of a difference in our case but the comprehension is slightly faster than the function call.