### PR TITLE
Add linters to deltametrics: flake8-bugbear

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
   hooks:
   - id: flake8
     additional_dependencies:
-    # - flake8-bugbear
+    - flake8-bugbear
     - flake8-comprehensions
     - flake8-simplify
     exclude: ^docs/source/pyplots/guides/.*$

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -579,7 +579,8 @@ class BaseCube(abc.ABC):
             "alternatives. To quickly show a planform slice of a cube, you "
             "can use `quick_show()` with a similar API. The `show_planform` "
             "method implements more features, but requires instantiating a "
-            "`Planform` object first. Passing arguments to `quick_show`."
+            "`Planform` object first. Passing arguments to `quick_show`.",
+            stacklevel=2,
         )
         # pass `t` arg to `idx` for legacy
         if "t" in kwargs.keys():

--- a/deltametrics/cube.py
+++ b/deltametrics/cube.py
@@ -40,7 +40,7 @@ class BaseCube(abc.ABC):
 
     """
 
-    def __init__(self, data, read=[], varset=None, dimensions=None):
+    def __init__(self, data, read=(), varset=None, dimensions=None):
         """Initialize the BaseCube.
 
         Parameters
@@ -644,7 +644,7 @@ class DataCube(BaseCube):
     """
 
     def __init__(
-        self, data, read=[], varset=None, stratigraphy_from=None, dimensions=None
+        self, data, read=(), varset=None, stratigraphy_from=None, dimensions=None
     ):
         """Initialize the BaseCube.
 
@@ -889,7 +889,7 @@ class StratigraphyCube(BaseCube):
     def __init__(
         self,
         data,
-        read=[],
+        read=(),
         varset=None,
         stratigraphy_from=None,
         sigma_dist=None,

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -246,6 +246,7 @@ class NetCDFIO(FileIO):
                 "with DeltaMetrics. This warning may be replaced "
                 "with an Error in a future version.",
                 UserWarning,
+                stacklevel=2,
             )
         else:
             # coordinates were not found and are not being set
@@ -270,7 +271,9 @@ class NetCDFIO(FileIO):
             self.meta = _meta
         except OSError:
             warnings.warn(
-                "No associated metadata was found in the given data file.", UserWarning
+                "No associated metadata was found in the given data file.",
+                UserWarning,
+                stacklevel=2,
             )
             self.meta = None
 

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -384,7 +384,7 @@ class DictionaryIO(BaseIO):
             # get the coordinates and dimensions from the data
             self.dims = under.dims
             self.coords = [under.coords[dim].data for dim in self.dims]
-            self.dimensions = dict(zip(self.dims, self.coords))
+            self.dimensions = dict(zip(self.dims, self.coords, strict=True))
         # otherwise, check for the arguments passed
         elif not (dimensions is None):
             # if dimensions was passed, it must be a dictionary
@@ -418,7 +418,7 @@ class DictionaryIO(BaseIO):
             self.coords = coords
 
         self.known_coords = self.dims
-        self.dimensions = dict(zip(self.dims, self.coords))
+        self.dimensions = dict(zip(self.dims, self.coords, strict=True))
 
     def connect(self, *args, **kwargs):
         """Connect to the data file.

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -398,7 +398,7 @@ class DictionaryIO(BaseIO):
                 raise ValueError("`dimensions` must contain three dimensions!")
             # use the dimensions keys as dims and the vals as coords
             #   note, we check the size against the underlying a we go
-            for i, (k, v) in enumerate(dimensions.items()):
+            for i, k in enumerate(dimensions):
                 if not (len(dimensions[k]) == under_shp[i]):
                     raise ValueError(
                         "Shape of `dimensions` at position {} was {}, "

--- a/deltametrics/io.py
+++ b/deltametrics/io.py
@@ -219,7 +219,7 @@ class NetCDFIO(FileIO):
             # open the dataset
             _dataset = xr.open_dataset(self.data_path, engine=_engine)
         except Exception as e:
-            raise TypeError(f"File format out of scope for DeltaMetrics: {e}")
+            raise TypeError(f"File format out of scope for DeltaMetrics: {e}") from e
 
         # try to find if coordinates have been preconfigured
         _coords_list = list(_dataset.coords)

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -279,7 +279,8 @@ class BaseMask(abc.ABC):
                 DeprecationWarning(
                     "The `is_mask` argument is deprecated. "
                     "It does not have any functionality."
-                )
+                ),
+                stacklevel=2,
             )
 
     def _check_deprecated_3d_input(self, args_0_shape):

--- a/deltametrics/mask.py
+++ b/deltametrics/mask.py
@@ -2108,13 +2108,11 @@ class CenterlineMask(BaseMask):
                 from rivamap.singularity_index import applyMMSI as MMSI
                 from rivamap.singularity_index import SingularityIndexFilters as SF
                 from rivamap.delineate import extractCenterlines as eCL
-            except ImportError:
+            except ImportError as err:
                 raise ImportError(
                     "You must install the optional dependency: rivamap, to "
                     "use the centerline extraction method."
-                )
-            except Exception as e:
-                raise e
+                ) from err
 
             # pop the kwargs
             self.minScale = kwargs.pop("minScale", 1.5)

--- a/deltametrics/mobility.py
+++ b/deltametrics/mobility.py
@@ -137,14 +137,14 @@ def check_inputs(chmap, basevalues=None, basevalues_idx=None, window=None,
             basevalues = [np.argmin(
                 np.abs(out_maps['chmap'].time.data - i))
                 for i in baselist]
-        except Exception:
-            raise TypeError('basevalues was not a list or list-able obj.')
+        except Exception as err:
+            raise TypeError('basevalues was not a list or list-able obj.') from err
 
     if (basevalues_idx is not None):
         try:
             basevalues_idx = list(basevalues_idx)
-        except Exception:
-            raise TypeError('basevalues_idx was not a list or list-able obj.')
+        except Exception as err:
+            raise TypeError('basevalues_idx was not a list or list-able obj.') from err
 
     if (basevalues is not None) and (basevalues_idx is not None):
         raise Warning(

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -83,7 +83,8 @@ class BasePlanform(abc.ABC):
                         "`Planform` object. To change the name of "
                         "a Planform, you must set the attribute "
                         "directly with `plan._name = 'name'`."
-                    )
+                    ),
+                    stacklevel=2,
                 )
             # do nothing
 

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1053,11 +1053,11 @@ class MorphologicalPlanform(SpecialtyPlanform):
         elif isinstance(self.cube, BaseCube):
             try:
                 self._max_disk = self.cube.meta["N0"].data
-            except Exception:
+            except Exception as err:
                 raise TypeError(
                     "Data cube does not contain metadata, you must "
                     "specify the inlet size."
-                )
+                ) from err
         else:
             raise TypeError(
                 "Something went wrong. Check second input argument for " "inlet width."

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1896,7 +1896,7 @@ def shaw_opening_angle_method(
         test_set_points = land_points
     else:
         raise ValueError(
-            f"Invalid option '{test_set}' for `test_set` parameter was supplied."
+            f"Invalid option {test_set!r} for `test_set` parameter was supplied."
         )
 
     # Find convex hull
@@ -1929,7 +1929,7 @@ def shaw_opening_angle_method(
         outside_hull_value = 0
     else:
         raise ValueError(
-            f"Invalid option '{query_set}' for `query_set` parameter was supplied."
+            f"Invalid option {query_set!r} for `query_set` parameter was supplied."
         )
 
     # Compute opening angle

--- a/deltametrics/plan.py
+++ b/deltametrics/plan.py
@@ -1323,7 +1323,7 @@ def compute_shoreline_roughness(shore_mask, land_mask, **kwargs):
     return rough
 
 
-def compute_shoreline_length(shore_mask, origin=[0, 0], return_line=False):
+def compute_shoreline_length(shore_mask, origin=(0, 0), return_line=False):
     """Compute the length of a shoreline from a mask of the shoreline.
 
     Algorithm attempts to determine the sorted coordinates of the shoreline
@@ -1554,7 +1554,7 @@ def compute_shoreline_length(shore_mask, origin=[0, 0], return_line=False):
         return length
 
 
-def compute_shoreline_distance(shore_mask, origin=[0, 0], return_distances=False):
+def compute_shoreline_distance(shore_mask, origin=(0, 0), return_distances=False):
     """Compute mean and stddev distance from the delta apex to the shoreline.
 
     Algorithm computes the mean distance from the delta apex/origin to all

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -1399,7 +1399,7 @@ def aerial_view(
     datum=0,
     ax=None,
     ticks=False,
-    colorbar_kw={},
+    colorbar_kw=None,
     return_im=False,
     **kwargs,
 ):
@@ -1457,6 +1457,7 @@ def aerial_view(
         >>> fig, ax = plt.subplots()
         >>> _ = aerial_view(elevation_data, ax=ax)
     """
+    colorbar_kw = {} if colorbar_kw is None else colorbar_kw
     if not ax:
         fig, ax = plt.subplots()
 

--- a/deltametrics/plot.py
+++ b/deltametrics/plot.py
@@ -1088,7 +1088,7 @@ def _fill_steps(where, x=1, y=1, y0=0, **kwargs):
         Collection of `Rectangle` `Patch` objects.
     """
     pl = []
-    for i, pp in enumerate(np.argwhere(where[1:]).flatten()):
+    for _, pp in enumerate(np.argwhere(where[1:]).flatten()):
         _r = ptch.Rectangle((pp, y0), x, y, **kwargs)
         pl.append(_r)
     return coll.PatchCollection(pl, match_original=True)

--- a/deltametrics/sample_data/cube.py
+++ b/deltametrics/sample_data/cube.py
@@ -18,5 +18,6 @@ def rcm8():
         "Access is maintained here for backwards compatability, "
         "but will be removed in a future release.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return moved_rcm8()

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -736,7 +736,7 @@ class BaseSection(abc.ABC):
         lims = [ax.get_xlim(), ax.get_ylim()]
 
         # add the trace
-        ax.plot(_x, _y, label=_label, *args, **kwargs)
+        ax.plot(_x, _y, *args, label=_label, **kwargs)
 
         # if autscale is false, reset the axes
         if not autoscale:

--- a/deltametrics/section.py
+++ b/deltametrics/section.py
@@ -293,7 +293,8 @@ class BaseSection(abc.ABC):
                         "`Section` object. To change the name of "
                         "a Section, you must set the attribute "
                         "directly with `section._name = 'name'`."
-                    )
+                    ),
+                    stacklevel=2,
                 )
             # do nothing
 
@@ -967,7 +968,8 @@ class LineSection(BaseSection):
                     "in a future release. Please use `distance_idx` and "
                     "`length` to continue to specify cell indices, or "
                     "use `distance` and `length` to specify "
-                    "coordinate values."
+                    "coordinate values.",
+                    stacklevel=2,
                 )
                 if direction == "strike":
                     distance_idx = y
@@ -1207,7 +1209,10 @@ class StrikeSection(LineSection):
     @property
     def y(self):
         """Deprecated. Use :obj:`distance_idx`."""
-        warnings.warn("`.y` is a deprecated attribute. Use `.distance_idx` instead.")
+        warnings.warn(
+            "`.y` is a deprecated attribute. Use `.distance_idx` instead.",
+            stacklevel=2,
+        )
         return self._distance_idx
 
     @property
@@ -1216,7 +1221,10 @@ class StrikeSection(LineSection):
 
         Start and end indices of section.
         """
-        warnings.warn("`.x` is a deprecated attribute. Use `.length_idx` instead.")
+        warnings.warn(
+            "`.x` is a deprecated attribute. Use `.length_idx` instead.",
+            stacklevel=2,
+        )
         return self._length_idx
 
 
@@ -1418,7 +1426,10 @@ class DipSection(LineSection):
     @property
     def y(self):
         """Deprecated. Use :obj:`length_idx`."""
-        warnings.warn("`.y` is a deprecated attribute. Use `.length_idx` instead.")
+        warnings.warn(
+            "`.y` is a deprecated attribute. Use `.length_idx` instead.",
+            stacklevel=2,
+        )
         return self._length_idx
 
     @property
@@ -1427,7 +1438,10 @@ class DipSection(LineSection):
 
         Start and end indices of section.
         """
-        warnings.warn("`.x` is a deprecated attribute. Use `.distance_idx` instead.")
+        warnings.warn(
+            "`.x` is a deprecated attribute. Use `.distance_idx` instead.",
+            stacklevel=2,
+        )
         return self._distance_idx
 
 
@@ -1602,8 +1616,10 @@ class CircularSection(BaseSection):
                     # try and guess the value (should issue a warning?)
                     #   if no field called 'eta'?? this will fail.
                     warnings.warn(
-                        "Trying to guess origin distance from dim1==0. "
-                        "This is unlikely to work for data not generated from pyDeltaRCM."
+                        "Trying to guess origin distance from dim1==0."
+                        " This is unlikely to work for data not generated from"
+                        " pyDeltaRCM.",
+                        stacklevel=2,
                     )
                     land_width = np.minimum(
                         guess_land_width_from_land(
@@ -1852,8 +1868,10 @@ class RadialSection(BaseSection):
                     # try and guess the value (should issue a warning?)
                     #   if no field called 'eta'?? this will fail.
                     warnings.warn(
-                        "Trying to guess origin distance from dim1==0. "
-                        "This is unlikely to work for data not generated from pyDeltaRCM."
+                        "Trying to guess origin distance from dim1==0."
+                        " This is unlikely to work for data not generated from"
+                        " pyDeltaRCM.",
+                        stacklevel=2,
                     )
                     land_width = np.minimum(
                         guess_land_width_from_land(

--- a/deltametrics/strat.py
+++ b/deltametrics/strat.py
@@ -1062,8 +1062,12 @@ def _determine_strat_coordinates(elev, z=None, dz=None, nz=None):
     # if nothing is supplied
     if (dz is None) and (z is None) and (nz is None):
         warnings.warn(
-            UserWarning('No specification for stratigraphy spacing '
-                        'was supplied. Default is to use `dz=0.1`'))
+            UserWarning(
+                "No specification for stratigraphy spacing"
+                " was supplied. Default is to use `dz=0.1`"
+            ),
+            stacklevel=2,
+        )
         # set the default option when nothing is supplied
         dz = 0.1
 

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -69,7 +69,7 @@ def needs_stratigraphy(func):
         try:
             return func(*args, **kwargs)
         except AttributeError as e:
-            raise NoStratigraphyError(e)
+            raise NoStratigraphyError(e) from e
     return decorator
 
 

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -119,7 +119,7 @@ class AttributeChecker:
 
         log_list = list(att_dict.values())
         log_form = [value for string, value in
-                    zip(log_list, att_dict.keys()) if not string]
+                    zip(log_list, att_dict.keys(), strict=True) if not string]
         if not all(log_list):
             raise RuntimeError('Required attribute(s) not assigned: '
                                + str(log_form))

--- a/deltametrics/utils.py
+++ b/deltametrics/utils.py
@@ -110,7 +110,7 @@ class AttributeChecker:
             raise TypeError('Checklist must be of type `list`,'
                             'but was type: %s' % type(checklist))
 
-        for c, check in enumerate(checklist):
+        for _, check in enumerate(checklist):
             has = getattr(self, check, None)
             if has is None:
                 att_dict[check] = False

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -790,7 +790,7 @@ class TestShowHistograms:
     def test_multiple_no_sets(self):
         sets = [np.histogram(np.random.normal(lc, s, size=500),
                 bins=self.bins, density=True) for lc, s in
-                zip(self.locs, self.scales)]
+                zip(self.locs, self.scales, strict=True)]
         fig, ax = plt.subplots()
         show_histograms(*sets, ax=ax)
         plt.close()
@@ -798,7 +798,7 @@ class TestShowHistograms:
     def test_multiple_no_sets_alphakwarg(self):
         sets = [np.histogram(np.random.normal(lc, s, size=500),
                 bins=self.bins, density=True) for lc, s in
-                zip(self.locs, self.scales)]
+                zip(self.locs, self.scales, strict=True)]
         fig, ax = plt.subplots()
         show_histograms(*sets, ax=ax, alpha=0.4)
         plt.close()
@@ -806,7 +806,7 @@ class TestShowHistograms:
     def test_multiple_with_sets(self):
         sets = [np.histogram(np.random.normal(lc, s, size=500),
                 bins=self.bins, density=True) for lc, s in
-                zip(self.locs, self.scales)]
+                zip(self.locs, self.scales, strict=True)]
         fig, ax = plt.subplots()
         show_histograms(*sets, sets=[0, 0, 1, 1, 2], ax=ax)
         plt.close()

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -813,7 +813,6 @@ class TestShowHistograms:
         with pytest.raises(ValueError, match=r'Number of histogram tuples*.'):
             # input lengths must match
             show_histograms(*sets, sets=[0, 1], ax=ax)
-            plt.close()
 
 
 class TestAerialView:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -761,7 +761,7 @@ class TestScaleLightness:
     def test_scale_down_red(self):
         red = (1.0, 0.0, 0.0)  # initial color red
         scales = np.arange(1, 0, -0.05)  # from 1 to 0.05
-        for s, scale in enumerate(scales):
+        for _, scale in enumerate(scales):
             darker_red = _scale_lightness(red, scale)
             assert darker_red[0] == pytest.approx(scale)
 

--- a/tests/test_section.py
+++ b/tests/test_section.py
@@ -84,7 +84,7 @@ class TestStrikeSection:
             rcm8cube.register_section(
                 "testname", StrikeSection(distance_idx=5, name="TESTING")
             )
-            assert rcm8cube.sections["testname"].name == "TESTING"
+        assert rcm8cube.sections["testname"].name == "TESTING"
         _sect = rcm8cube.register_section(
             "test", StrikeSection(distance_idx=5), return_section=True
         )
@@ -238,7 +238,7 @@ class TestPathSection:
             rcm8cube.register_section(
                 "test2", PathSection(path_idx=self.test_path, name="trial")
             )
-            assert rcm8cube.sections["test2"].name == "trial"
+        assert rcm8cube.sections["test2"].name == "trial"
         _section = rcm8cube.register_section(
             "test", PathSection(path_idx=self.test_path), return_section=True
         )
@@ -372,7 +372,7 @@ class TestCircularSection:
             rcm8cube.register_section(
                 "test2", CircularSection(radius_idx=31, name="diff")
             )
-            assert rcm8cube.sections["test2"].name == "diff"
+        assert rcm8cube.sections["test2"].name == "diff"
         rcm8cube.register_section("test3", CircularSection())
         assert rcm8cube.sections["test3"]._radius_idx == rcm8cube.shape[1] // 2
         _section = rcm8cube.register_section(
@@ -498,7 +498,7 @@ class TestRadialSection:
             rcm8cube.register_section(
                 "test2", RadialSection(azimuth=30, name="notthesame")
             )
-            assert rcm8cube.sections["test2"].name == "notthesame"
+        assert rcm8cube.sections["test2"].name == "notthesame"
         _section = rcm8cube.register_section(
             "test", RadialSection(azimuth=30), return_section=True
         )
@@ -1206,7 +1206,7 @@ class TestDipSection:
             rcm8cube.register_section(
                 "testname", DipSection(distance_idx=150, name="TESTING")
             )
-            assert rcm8cube.sections["testname"].name == "TESTING"
+        assert rcm8cube.sections["testname"].name == "TESTING"
         _sect = rcm8cube.register_section(
             "test", DipSection(distance_idx=150), return_section=True
         )


### PR DESCRIPTION
Adds the *flake8-bugbear* linter to *deltametrics* and fixes some issues.

Maybe the two biggest changes here are:
1. Set `stacklevel=2` for warnings. The default of 1 produces warnings that can be difficult to understand.
2. Use only immutable objects as keyword defaults. If you use a mutable object as a default and then change that object's value within the function, the default value for subsequent calls of the function will also change.