### PR TITLE
Name change

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,21 @@
-************
-DeltaMetrics
-************
+**********
+sandplover
+**********
 
-.. image:: https://github.com/DeltaRCM/DeltaMetrics/actions/workflows/build.yml/badge.svg?branch=develop
-  :target: https://github.com/DeltaRCM/DeltaMetrics/actions
+.. image:: https://github.com/sandpiper-toolchain/sandplover/actions/workflows/build.yml/badge.svg?branch=develop
+  :target: https://github.com/sandpiper-toolchain/sandplover/actions
 
-.. image:: https://codecov.io/gh/DeltaRCM/DeltaMetrics/branch/develop/graph/badge.svg
-  :target: https://codecov.io/gh/DeltaRCM/DeltaMetrics
+.. image:: https://codecov.io/gh/sandpiper-toolchain/sandplover/branch/develop/graph/badge.svg
+  :target: https://codecov.io/gh/sandpiper-toolchain/sandplover
 
-*DeltaMetrics* is a Python package for manipulating depositional system data cubes.
+*sandplover* is a Python package for manipulating depositional system data cubes.
 The package has robust objects and routines designed to help organize, visualize, and analyze topography and sedimentological timeseries data.
-*DeltaMetrics* works especially well with data from deltaic systems (e.g., the `pyDeltaRCM numerical model <https://github.com/DeltaRCM/pyDeltaRCM>`_  and laboratory delta experiments).
+*sandplover* works especially well with data from deltaic systems (e.g., the `pyDeltaRCM numerical model <https://github.com/DeltaRCM/pyDeltaRCM>`_  and laboratory delta experiments).
+This software was previously known as *DeltaMetrics*.
 
-`Full documentation here <https://deltarcm.org/DeltaMetrics/index.html>`_.
+`Full documentation here <https://sandpiper-toolchain.github.io/sandplover/index.html>`_.
 
 
-.. figure:: https://deltarcm.org/DeltaMetrics/_images/cover.png
+.. figure:: https://sandpiper-toolchain.github.io/sandplover/_images/cover.png
 
   A view of bed elevation on a modeled deltaic deposit in ``Planform``, and a cross ``StrikeSection`` view of the timing of sediment deposition in stratigraphy.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,15 +20,13 @@ def get_version_from_file(path_to_version_file: str) -> str:
     return module.__version__
 
 
-src_dir = os.path.abspath(
-    os.path.join(os.path.dirname(__file__), os.pardir, os.pardir)
-)
+src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
 
 # -- Project information -----------------------------------------------------
 
-project = 'DeltaMetrics'
-copyright = '2020, The DeltaRCM Team'
-author = 'The DeltaRCM Team'
+project = "DeltaMetrics"
+copyright = "2020, The DeltaRCM Team"
+author = "The DeltaRCM Team"
 
 __version__ = get_version_from_file(
     os.path.join(src_dir, "deltametrics", "_version.py")
@@ -44,18 +42,20 @@ version = __version__
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc',
-              'sphinx.ext.doctest',
-              'sphinx.ext.autosummary',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.graphviz',
-              'sphinx.ext.mathjax',
-              'sphinx.ext.githubpages',
-              'matplotlib.sphinxext.plot_directive',
-              'sphinx.ext.todo']
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.doctest",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.graphviz",
+    "sphinx.ext.mathjax",
+    "sphinx.ext.githubpages",
+    "matplotlib.sphinxext.plot_directive",
+    "sphinx.ext.todo",
+]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -78,30 +78,33 @@ napoleon_use_rtype = True
 # Autosummary / Automodapi settings
 autosummary_generate = True
 automodapi_inheritance_diagram = False
-autodoc_default_options = {'members': True, 'inherited-members': True,
-                           'private-members': False}
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": True,
+    "private-members": False,
+}
 
 # doctest
-doctest_global_setup = '''
+doctest_global_setup = """
 import deltametrics as dm
 import numpy as np
 from matplotlib import pyplot as plt
 import matplotlib
-'''
+"""
 
 # empty string disables testing all code in any docstring
-doctest_test_doctest_blocks = ''
+doctest_test_doctest_blocks = ""
 
 # mpl plots
-plot_basedir = 'pyplots'
+plot_basedir = "pyplots"
 plot_html_show_source_link = True
-plot_include_source = True
-plot_formats = ['png', ('hires.png', 300)]
-plot_pre_code = '''
+plot_include_source = False
+plot_formats = ["png", ("hires.png", 300)]
+plot_pre_code = """
 import numpy as np
 from matplotlib import pyplot as plt
 import deltametrics as dm
-'''
+"""
 
 # img math
 # imgmath_latex_preamble = '\\usepackage{fouriernc}' # newtxsf, mathptmx
@@ -111,9 +114,9 @@ import deltametrics as dm
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinxdoc'
+html_theme = "sphinxdoc"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]


### PR DESCRIPTION

- Change the name of the package at the very highest level references.
- restore the link to the documentation.
- disable the show source code by default. without carefully making this change, it clutters up the docs and makes it hard to read. I'm open to changing the default behavior in the future, but we need to do it along with a comb through the docs.

