### PR TITLE
Only run CI jobs on external pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,11 @@ concurrency:
 
 jobs:
   build:
+    # Run on external PRs, but not on internal PRs, to avoid duplicate runs
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -47,6 +52,11 @@ jobs:
         fail_ci_if_error: false
 
   lint:
+    # Run on external PRs, but not on internal PRs, to avoid duplicate runs
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: "ubuntu-latest"
 
     steps:
@@ -64,6 +74,11 @@ jobs:
       run: nox -s lint
 
   docs:
+    # Run on external PRs, but not on internal PRs, to avoid duplicate runs
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     steps:
     - name: Checkout


### PR DESCRIPTION
Our CI *build* workflow is triggered by both `push` and `pull_request` events. This means that when a pull request is made from the same repository (i.e. not a fork) the workflow is run twice. I've added some code to ensure the workflow jobs are only run on a `pull_request` event if the pull request is from a fork. If the pull request is from the same repository (like this pr is), the workflow is only run for the `push` trigger.