### PR TITLE
Rename DeltaRCM team to sandpiper-toolchain team

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 The DeltaRCM team
+Copyright (c) 2020 The sandpiper-toolchain team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 The sandpiper-toolchain team
+Copyright (c) 2025 The sandpiper-toolchain team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,8 +25,8 @@ src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.
 # -- Project information -----------------------------------------------------
 
 project = "sandplover"
-copyright = "2020, The DeltaRCM Team"
-author = "The DeltaRCM Team"
+copyright = "2020, The sandpiper-toolchain Team"
+author = "The sandpiper-toolchain Team"
 
 __version__ = get_version_from_file(os.path.join(src_dir, "sandplover", "_version.py"))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ src_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, os.
 # -- Project information -----------------------------------------------------
 
 project = "sandplover"
-copyright = "2020, The sandpiper-toolchain Team"
+copyright = "2025, The sandpiper-toolchain Team"
 author = "The sandpiper-toolchain Team"
 
 __version__ = get_version_from_file(os.path.join(src_dir, "sandplover", "_version.py"))

--- a/docs/source/meta/license.rst
+++ b/docs/source/meta/license.rst
@@ -2,4 +2,4 @@
 License
 ************
 
-This project is licensed under the MIT License - see the `full license <https://github.com/deltarcm/sandplover/blob/develop/LICENSE.txt>`_  file for details. It is provided without warranty or guaranteed support.
+This project is licensed under the MIT License - see the `full license <https://github.com/sandpiper-toolchain/sandplover/blob/develop/LICENSE.txt>`_  file for details. It is provided without warranty or guaranteed support.


### PR DESCRIPTION
The ***DeltaRCM Team*** is now the ***sandpiper-toolchain Team***, I think. I also bumped the copyright year to 2025 (I don't know if that really matters or not).