### PR TITLE
Update the deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,16 @@ jobs:
       id-token: write
 
     steps:
+    - uses: actions/checkout@v4
+    - name: Use Python 3.13
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.13"
+    - name: Build
+      shell: bash
+      run: |
+        pip install nox
+        nox -s build
     - name: Publish
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,24 +9,16 @@ on:
 
 jobs:
   deploy:
-
+    name: Deploy to PyPI
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-        pip install -r requirements.txt
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
+        repository-url: https://upload.pypi.org/legacy/
+        skip-existing: true
+        print-hash: true
+        verify-metadata: false


### PR DESCRIPTION
I've updated the *sandplover* workflow to use the [pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish) action to upload distributions to PyPI.

Instead of using `PYPI_USERNAME` and `PYPI_PASSWORD`, I've added our GitHub organization as a trusted publisher for *sandplover* (for both PyPI and Test-PyPI).