### PR TITLE
update to use xarray DataTree

### DIFF
--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -215,7 +215,7 @@ class NetCDFIO(FileIO):
 
         try:
             # open the dataset
-            _dataset = xr.open_dataset(self.data_path, engine=_engine)
+            _dataset = xr.open_datatree(self.data_path, engine=_engine)
         except Exception as e:
             raise TypeError(f"File format out of scope for sandplover: {e}") from e
 
@@ -227,16 +227,22 @@ class NetCDFIO(FileIO):
             warnings.filterwarnings("ignore", category=FutureWarning)
             _dims_set = set(_dataset.dims.keys())
         if len(_coords_list) == 3:
+            _LEGACY = False
             # the coordinates are preconfigured
-            self.dataset = _dataset.set_coords(_coords_list)
+            self.dataset = _dataset  # .set_coords(_coords_list)
             self.coords = list(self.dataset.coords)
             self.dims = copy.deepcopy(self.coords)
+
         elif {"total_time", "length", "width"}.issubset(_dims_set):
+            # ONLY SUPPORT UNTIL v1.0
+            _LEGACY = True
             # the coordinates are not set, but there are matching arrays
-            # this is a legacy option, so issue a warning here
+            #   need to reopen the dataset as old non-tree version
+            _dataset = xr.open_dataset(self.data_path, engine=_engine)
             self.dataset = _dataset.set_coords(["x", "y", "time"])
             self.dims = ["time", "length", "width"]
             self.coords = ["total_time", "x", "y"]
+            # this is a legacy option, so issue a warning here
             warnings.warn(
                 'Coordinates for "time", and ("y", "x") were found as '
                 "variables in the underlying data file, "
@@ -265,16 +271,36 @@ class NetCDFIO(FileIO):
             # warn('Coordinates for "time", and set("x", "y") not provided in the \
             #       given data file.', UserWarning)
 
-        try:
-            _meta = xr.open_dataset(self.data_path, group="meta", engine=_engine)
-            self.meta = _meta
-        except OSError:
-            warnings.warn(
-                "No associated metadata was found in the given data file.",
-                UserWarning,
-                stacklevel=2,
-            )
-            self.meta = None
+        if _LEGACY:
+            try:
+                _meta = xr.open_dataset(self.data_path, group="meta", engine=_engine)
+            except OSError:
+                warnings.warn(
+                    "No associated metadata was found in the given data file.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self.meta = None
+
+        else:
+            # check for a matching meta field, and set it accordingly
+            if "/metadata" in self.dataset.groups:
+                self.meta = self.dataset["metadata"]
+            elif "/meta" in self.dataset.groups:
+                self.meta = self.dataset["meta"]
+                warnings.warn(
+                    "Metadata found with group name `meta`, but this specification "
+                    "is deprecated. Change group name to `metadata`.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                warnings.warn(
+                    "No associated metadata was found in the given data file.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self.meta = None
 
     def get_known_variables(self):
         """List known variables.

--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -229,7 +229,7 @@ class NetCDFIO(FileIO):
         if len(_coords_list) == 3:
             _LEGACY = False
             # the coordinates are preconfigured
-            self.dataset = _dataset  # .set_coords(_coords_list)
+            self.dataset = _dataset
             self.coords = list(self.dataset.coords)
             self.dims = copy.deepcopy(self.coords)
 
@@ -274,6 +274,7 @@ class NetCDFIO(FileIO):
         if _LEGACY:
             try:
                 _meta = xr.open_dataset(self.data_path, group="meta", engine=_engine)
+                self.meta = _meta
             except OSError:
                 warnings.warn(
                     "No associated metadata was found in the given data file.",


### PR DESCRIPTION
## This PR

Implement the new `xarray` `DataTree` class in the data io layer. 

Using the `DataTree` allows for hierarchical structure in the underlying file (e.g. the `metadata` group we currently work with). Adopting DataTree simplifies some of the data io layer, but complicated some too. The change happens at the IO layer, so it is seamless for the sandplover API. It is possible it may allow us to simplify some of the calls between the public api and the data layer, but I haven't completely explored this yet.

The bit that is more complicated is the support for the legacy format of pydeltarcm files. As far as I know, no one is creating legacy pydeltarcm files anymore (it has long been considered legacy there), and so there is basically no chance  someone is using those *and* sandplover. 

**This is a non-breaking change**

closes #4 

## Moving forward

**Proposal for consideration:** So, I am proposing to also drop sandplover support handling those legacy files. Instead, sandplover will consider a new set of formats as "legacy" moving forward, which will be determined based on the implementation of `sandsuet`. 

If we agree to this proposal to drop the legacy option, I will also merge #206.

This PR represents the first in a long-term series that will implement changes to adopt the sandsuet spec.