### PR TITLE
clinic fixes

### DIFF
--- a/docs/source/guides/subject_guides/visualization.rst
+++ b/docs/source/guides/subject_guides/visualization.rst
@@ -3,6 +3,29 @@ Visualization Guide
 
 This guide covers the full range of visualization routines available as part of sandplover, and explains how to create your own visualization routines that build on top of DeltaMetrics.
 
+There are built-in visualization tools in sandplover, which are for the most part attached to the object that you would want to visualize itself.
+For example, to visualize a section: 
+
+.. code::
+
+    spl.section.RadialSection(golfcube, azimuth=70).show("velocity")
+
+There are also built-in visualization style configurations that control the display of certian variables throughout the software.
+The goal with these style configurations is to reduce the number of steps needed to make visualizations during data analysis and figure production. 
+
+This guide is broken into two sections, first explaining these visualization style configurations, then explaining the various built-in methods for displaying data. 
+
+Style Configurations
+~~~~~~~~~~~~~~~~~~~~
+
+Style configurations for different variables in the underlying data of a `Cube` are determined by :obj:`~sandplover.plot.VariableInfo` objects that are organized into a dictionary-like :obj:`~sandpover.plot.VariableSet` object. 
+The `VariableSet` is created during instantiation of every `Cube`; an existing `VariableSet` can be provided as an optional argument during `Cube` instantiation. 
+
+There are several variable names that are recognized by the `VariableSet` and receive specific styling (e.g., `eta`, `velocity`). 
+
+.. warning::
+
+    The automatic detection of variable names may be removed in the future. 
 
 
 Default styling
@@ -15,8 +38,24 @@ The default parameters of each styling variable are defined below:
 
 
 
-Section display types
----------------------
+
+Data Visualization Methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cube display methods
+--------------------
+
+todo...
+
+
+Planform display methods
+------------------------
+
+todo...
+
+
+Section display methods
+-----------------------
 
 `DataCube` with computed "quick" stratigraphy may be visualized a number of different ways.
 

--- a/docs/source/guides/subject_guides/visualization.rst
+++ b/docs/source/guides/subject_guides/visualization.rst
@@ -4,28 +4,28 @@ Visualization Guide
 This guide covers the full range of visualization routines available as part of sandplover, and explains how to create your own visualization routines that build on top of DeltaMetrics.
 
 There are built-in visualization tools in sandplover, which are for the most part attached to the object that you would want to visualize itself.
-For example, to visualize a section: 
+For example, to visualize a section:
 
 .. code::
 
     spl.section.RadialSection(golfcube, azimuth=70).show("velocity")
 
 There are also built-in visualization style configurations that control the display of certian variables throughout the software.
-The goal with these style configurations is to reduce the number of steps needed to make visualizations during data analysis and figure production. 
+The goal with these style configurations is to reduce the number of steps needed to make visualizations during data analysis and figure production.
 
-This guide is broken into two sections, first explaining these visualization style configurations, then explaining the various built-in methods for displaying data. 
+This guide is broken into two sections, first explaining these visualization style configurations, then explaining the various built-in methods for displaying data.
 
 Style Configurations
 ~~~~~~~~~~~~~~~~~~~~
 
-Style configurations for different variables in the underlying data of a `Cube` are determined by :obj:`~sandplover.plot.VariableInfo` objects that are organized into a dictionary-like :obj:`~sandpover.plot.VariableSet` object. 
-The `VariableSet` is created during instantiation of every `Cube`; an existing `VariableSet` can be provided as an optional argument during `Cube` instantiation. 
+Style configurations for different variables in the underlying data of a `Cube` are determined by :obj:`~sandplover.plot.VariableInfo` objects that are organized into a dictionary-like :obj:`~sandpover.plot.VariableSet` object.
+The `VariableSet` is created during instantiation of every `Cube`; an existing `VariableSet` can be provided as an optional argument during `Cube` instantiation.
 
-There are several variable names that are recognized by the `VariableSet` and receive specific styling (e.g., `eta`, `velocity`). 
+There are several variable names that are recognized by the `VariableSet` and receive specific styling (e.g., `eta`, `velocity`).
 
 .. warning::
 
-    The automatic detection of variable names may be removed in the future. 
+    The automatic detection of variable names may be removed in the future.
 
 
 Default styling

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -113,9 +113,11 @@ Remember that `time` is ordered along the 0th dimension.
 
 .. note::
 
-    The 0th dimension of the cube must be the *time* dimension, and the 1st and 2nd dimensions represent the spatial dimensions of the data domain, but can have any arbitrary "name" for the dimensions. For example, from *pyDeltaRCM* the 1st and 2nd dimensions are named `x` and `y` respectively (`x` is considered a downstream coordinate in that model). In `sandplover`, we refer to these spatial dimensions as `dim1` and `dim2`, because they may have any name.
+    The 0th dimension of the cube must be the *time* dimension, and the 1st and 2nd dimensions represent the spatial dimensions of the data domain, but can have any arbitrary "name" for the dimensions. 
+    For example, from *pyDeltaRCM* the 1st and 2nd dimensions are named `x` and `y` respectively (`x` is considered a downstream coordinate in that model). 
+    Internall and within `sandplover` documentation, we refer to the spatial dimensions as `dim1` and `dim2`, because they may have any name.
 
-The CubeVariable supports arbitrary math (using `xarray`).
+The returned array is like most other arrays you are used to in Python, and so supports arbitrary math (using `xarray`).
 For example:
 
 .. plot::
@@ -132,6 +134,20 @@ For example:
     >>> im = ax.imshow(diff_time, cmap="RdBu", vmax=max_delta, vmin=-max_delta)
     >>> cb = spl.plot.append_colorbar(im, ax)  # a convenience function
     >>> plt.show()
+
+In addition to slicing the variables in the underlying dataset, the `DataCube` also allows you to slice `"time"`, which is a variable of the same shape as the other variables in the dataset containing every row filled with the corresponding time coordinate value. 
+
+.. code::
+    
+    >>> golfcube["time"]
+
+This may not seem helpful at first, but it enables robust and consistent display of information in research concerned with :ref:`stratigraphy userguide_full_stratigraphy`_. 
+
+.. important::
+
+    sandplover overrides the slicing behavior to return this special variable called "time", even if there is a dimension/variable/coordinate in the underlying dataset also called "time".  
+
+To get a one-dimensional array of time coordinates for the `DataCube`, use :obj:`~sandplover.cube.DataCube.t`.
 
 
 Manipulating Planform data
@@ -406,6 +422,7 @@ See the :ref:`default colors in sandplover here <default_styling>` for more info
 
 Additionally, there are a :doc:`number of plotting routines <../reference/plot/index>` that are helpful in visualizations.
 
+.. _userguide_full_stratigraphy:
 
 Computing and Manipulating Stratigraphy
 #######################################

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -141,7 +141,7 @@ In addition to slicing the variables in the underlying dataset, the `DataCube` a
     
     >>> golfcube["time"]
 
-This may not seem helpful at first, but it enables robust and consistent display of information in research concerned with :ref:`stratigraphy userguide_full_stratigraphy`_. 
+This may not seem helpful at first, but it enables robust and consistent display of information in research concerned with :ref:`stratigraphy <userguide_full_stratigraphy>`.
 
 .. important::
 
@@ -390,6 +390,13 @@ Quick stratigraphy makes it easy to visualize the behavior of the model across e
 .. plot:: guides/userguide_quick_stratigraphy_all_variables.py
 
 
+.. hint::
+    
+    The labels in each panel above are determined by the value of the `label` attribute of the matching :obj:`~sandplover.plot.VariableInfo` attached to the `DataCube`. These `VariableInfo` objects are used throughout sandplover to style plots and label items, and are typically created during instantiation of the `DataCube`. 
+
+    See the :doc:`Visualization Guide </guides/subject_guides/visualization>` for a complete description and examples for configuring and creating visualtions in sandplover. 
+
+
 All Section types
 -----------------
 
@@ -410,15 +417,15 @@ The below figure shows each section type available and the `velocity` spacetime 
 .. plot:: guides/userguide_section_type_demos.py
 
 
-Default Colors in sandplover
-##############################
+Visualizations in sandplover
+############################
 
-You may have noticed the beautiful colors above, and be wondering: "how are the colors set?"
+You may have noticed the colors and labels above, and be wondering: "how are these options set?"
 We use a custom object (:obj:`~sandplover.plot.VariableSet`) to define common plotting properties for all plots.
 The `VariableSet` supports all kinds of other controls, such as custom colormaps for any variable, addition of new defined variables, fixed color limits, color normalizations, and more.
 You can also use these attributes of the `VariableSet` in your own plotting routines.
 
-See the :ref:`default colors in sandplover here <default_styling>` for more information.
+See the :doc:`Visualization Guide </guides/subject_guides/visualization>` for a complete description and examples for configuring and creating visualtions in sandplover. 
 
 Additionally, there are a :doc:`number of plotting routines <../reference/plot/index>` that are helpful in visualizations.
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -113,8 +113,8 @@ Remember that `time` is ordered along the 0th dimension.
 
 .. note::
 
-    The 0th dimension of the cube must be the *time* dimension, and the 1st and 2nd dimensions represent the spatial dimensions of the data domain, but can have any arbitrary "name" for the dimensions. 
-    For example, from *pyDeltaRCM* the 1st and 2nd dimensions are named `x` and `y` respectively (`x` is considered a downstream coordinate in that model). 
+    The 0th dimension of the cube must be the *time* dimension, and the 1st and 2nd dimensions represent the spatial dimensions of the data domain, but can have any arbitrary "name" for the dimensions.
+    For example, from *pyDeltaRCM* the 1st and 2nd dimensions are named `x` and `y` respectively (`x` is considered a downstream coordinate in that model).
     Internall and within `sandplover` documentation, we refer to the spatial dimensions as `dim1` and `dim2`, because they may have any name.
 
 The returned array is like most other arrays you are used to in Python, and so supports arbitrary math (using `xarray`).
@@ -135,17 +135,17 @@ For example:
     >>> cb = spl.plot.append_colorbar(im, ax)  # a convenience function
     >>> plt.show()
 
-In addition to slicing the variables in the underlying dataset, the `DataCube` also allows you to slice `"time"`, which is a variable of the same shape as the other variables in the dataset containing every row filled with the corresponding time coordinate value. 
+In addition to slicing the variables in the underlying dataset, the `DataCube` also allows you to slice `"time"`, which is a variable of the same shape as the other variables in the dataset containing every row filled with the corresponding time coordinate value.
 
 .. code::
-    
+
     >>> golfcube["time"]
 
-This may not seem helpful at first, but it enables robust and consistent display of information in research concerned with :ref:`stratigraphy userguide_full_stratigraphy`_. 
+This may not seem helpful at first, but it enables robust and consistent display of information in research concerned with :ref:`stratigraphy userguide_full_stratigraphy`_.
 
 .. important::
 
-    sandplover overrides the slicing behavior to return this special variable called "time", even if there is a dimension/variable/coordinate in the underlying dataset also called "time".  
+    sandplover overrides the slicing behavior to return this special variable called "time", even if there is a dimension/variable/coordinate in the underlying dataset also called "time".
 
 To get a one-dimensional array of time coordinates for the `DataCube`, use :obj:`~sandplover.cube.DataCube.t`.
 

--- a/docs/source/guides/userguide.rst
+++ b/docs/source/guides/userguide.rst
@@ -391,10 +391,10 @@ Quick stratigraphy makes it easy to visualize the behavior of the model across e
 
 
 .. hint::
-    
-    The labels in each panel above are determined by the value of the `label` attribute of the matching :obj:`~sandplover.plot.VariableInfo` attached to the `DataCube`. These `VariableInfo` objects are used throughout sandplover to style plots and label items, and are typically created during instantiation of the `DataCube`. 
 
-    See the :doc:`Visualization Guide </guides/subject_guides/visualization>` for a complete description and examples for configuring and creating visualtions in sandplover. 
+    The labels in each panel above are determined by the value of the `label` attribute of the matching :obj:`~sandplover.plot.VariableInfo` attached to the `DataCube`. These `VariableInfo` objects are used throughout sandplover to style plots and label items, and are typically created during instantiation of the `DataCube`.
+
+    See the :doc:`Visualization Guide </guides/subject_guides/visualization>` for a complete description and examples for configuring and creating visualtions in sandplover.
 
 
 All Section types
@@ -425,7 +425,7 @@ We use a custom object (:obj:`~sandplover.plot.VariableSet`) to define common pl
 The `VariableSet` supports all kinds of other controls, such as custom colormaps for any variable, addition of new defined variables, fixed color limits, color normalizations, and more.
 You can also use these attributes of the `VariableSet` in your own plotting routines.
 
-See the :doc:`Visualization Guide </guides/subject_guides/visualization>` for a complete description and examples for configuring and creating visualtions in sandplover. 
+See the :doc:`Visualization Guide </guides/subject_guides/visualization>` for a complete description and examples for configuring and creating visualtions in sandplover.
 
 Additionally, there are a :doc:`number of plotting routines <../reference/plot/index>` that are helpful in visualizations.
 

--- a/docs/source/reference/plot/index.rst
+++ b/docs/source/reference/plot/index.rst
@@ -13,7 +13,7 @@ This reference page documents the lower-level utilities used to make this happen
 
 .. hint::
 
-  There is a complete :doc:`Visualization Guide </guides/subject_guides/visualization>` about the organization of this area of sandplover and examples for how to use and make visualizations.
+  There is a complete :doc:`Visualization Guide </guides/subject_guides/visualization>`  about the organization of this area of sandplover, and examples for how to use and make visualizations.
 
 The functions are defined in ``sandplover.plot``.
 

--- a/sandplover/cube.py
+++ b/sandplover/cube.py
@@ -543,7 +543,6 @@ class BaseCube(abc.ABC):
         p = pv.Plotter()
         p.add_mesh(mesh.outline(), color="k")
         if style == "mesh":
-
             threshed = mesh.threshold([-np.inf, np.inf], all_scalars=True)
             p.add_mesh(threshed, cmap=self.varset[var].cmap)
 
@@ -800,12 +799,21 @@ class DataCube(BaseCube):
 
     @property
     def t(self):
-        """time coordinate."""
+        """time coordinate.
+
+        This is a one-dimensional array of the time coordinates of the
+        `DataCube`.
+        """
         return self._t
 
     @property
     def T(self):
-        """Vertical mesh."""
+        """Time mesh.
+
+        This is a three-dimensional representation of the time coordinate of
+        the `DataCube`. Every element of each row (i.e., layer) of the returned array is filled
+        with the corresponding time coordinate value.
+        """
         return self._T
 
 


### PR DESCRIPTION
This PR addresses some suggestions made in a CSDMS clinic (#204).

* improves documentation for the .t and .T DataCube attributes, and add some narrative explanation about these attributes and overriding the slicing of ['time'] to the userguide.