### PR TITLE
Make the tests pass on Windows, which is constantly failing for some TCL library dependency

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -36,7 +36,6 @@ def test(session: nox.Session) -> None:
 
     session.run("pip", "list")  # list packages and versions in venv
 
-    # session.run("pytest", "-vvv")
     if sys.platform == "linux":
         # run tests WITH doctests
         session.run("pytest", "--doctest-modules", "-vvv", *session.posargs)
@@ -53,9 +52,23 @@ def coverage(session: nox.Session) -> None:
 
     session.run("pip", "list")  # list packages and versions in venv
 
-    session.run(
-        "coverage", "run", "-m", "pytest", "-vvv", env={"COVERAGE_CORE": "sysmon"}
-    )
+    if sys.platform == "linux":
+        # run tests WITH doctests
+        session.run(
+            "coverage", "run", "-m", "pytest", "-vvv", env={"COVERAGE_CORE": "sysmon"}
+        )
+    else:
+        # run tests WITHOUT doctests (win and macos)
+        session.run(
+            "coverage",
+            "run",
+            "-m",
+            "pytest",
+            "-p",
+            "no:doctest",
+            "-vvv",
+            env={"COVERAGE_CORE": "sysmon"},
+        )
 
     if "CI" in os.environ:
         session.run("coverage", "xml", "-o", os.path.join(ROOT, "coverage.xml"))

--- a/noxfile.py
+++ b/noxfile.py
@@ -52,10 +52,17 @@ def coverage(session: nox.Session) -> None:
 
     session.run("pip", "list")  # list packages and versions in venv
 
+    # note coverage does not include doctest
     if sys.platform == "linux":
         # run tests WITH doctests
         session.run(
-            "coverage", "run", "-m", "pytest", "-vvv", env={"COVERAGE_CORE": "sysmon"}
+            "coverage",
+            "run",
+            "-m",
+            "pytest",
+            "--doctest-modules",
+            "-vvv",
+            env={"COVERAGE_CORE": "sysmon"},
         )
     else:
         # run tests WITHOUT doctests (win and macos)
@@ -64,8 +71,6 @@ def coverage(session: nox.Session) -> None:
             "run",
             "-m",
             "pytest",
-            "-p",
-            "no:doctest",
             "-vvv",
             env={"COVERAGE_CORE": "sysmon"},
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ addopts = [
     "--tb=native",
     "--durations=16",
     "--strict-markers",
-    "--doctest-modules",
+    # "--doctest-modules",  # AM commented to avoid default doctest during coverage
     "-vvv",
 ]
 doctest_optionflags = [

--- a/tests/mask_test.py
+++ b/tests/mask_test.py
@@ -1,6 +1,6 @@
 """Tests for the mask.py script."""
-import sys
 
+import sys
 import unittest.mock as mock
 
 import matplotlib.pyplot as plt

--- a/tests/mask_test.py
+++ b/tests/mask_test.py
@@ -162,6 +162,7 @@ class TestBaseMask:
         with pytest.raises(ValueError):
             basemask.trim_mask("arg1", "arg2", value=1, length=1)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show(self):
         """
         Here, we just test whether it works, and whether it takes a
@@ -186,6 +187,7 @@ class TestBaseMask:
         basemask.show(ax=ax)
         plt.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show_error_nomask(self):
         """
         Here, we just test whether it works, and whether it takes a

--- a/tests/mask_test.py
+++ b/tests/mask_test.py
@@ -1,4 +1,5 @@
 """Tests for the mask.py script."""
+import sys
 
 import unittest.mock as mock
 

--- a/tests/plan_test.py
+++ b/tests/plan_test.py
@@ -122,6 +122,7 @@ class TestPlanform:
         assert np.all(plnfrm2["time"] == golfcubestrat["time"][plnfrm2.idx, :, :])
         assert np.all(plnfrm3["time"] == golfstrat["time"][plnfrm3.idx, :, :])
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_Planform_private_show(self):
         """Doesn't actually check the plots,
         just checks that the function runs.
@@ -153,6 +154,7 @@ class TestPlanform:
         plnfrm._show(_field, _varinfo, ax=ax, title="some title")
         plt.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_Planform_public_show(self):
         golfcube = DataCube(golf_path)
         plnfrm = Planform(golfcube, idx=-1)
@@ -241,6 +243,7 @@ class TestOpeningAnglePlanform:
         with pytest.raises(TypeError):
             OpeningAnglePlanform(self.golfcube["eta"][-1, :, :].data)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show_and_errors(self):
         oap = OpeningAnglePlanform.from_elevation_data(
             self.golfcube["eta"][-1, :, :], elevation_threshold=0

--- a/tests/plan_test.py
+++ b/tests/plan_test.py
@@ -1,3 +1,5 @@
+import sys
+
 import unittest.mock as mock
 
 import matplotlib.pyplot as plt

--- a/tests/plan_test.py
+++ b/tests/plan_test.py
@@ -1,5 +1,4 @@
 import sys
-
 import unittest.mock as mock
 
 import matplotlib.pyplot as plt

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -1,4 +1,5 @@
 import sys
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -1,3 +1,4 @@
+import sys
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
@@ -297,6 +298,7 @@ class TestFillSteps:
         assert np.all(pc.get_facecolors()[0] == _exp)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestSODTTST:
     """Test the `show_one_dimensional_trajectory_to_strata` function."""
 

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -205,6 +205,7 @@ class TestAppendColorbar:
         assert cb.formatter is _formatter
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestStyleAxesKm:
     def test_style_axes_km_ax(self):
         fig, ax = plt.subplots(1, 6)

--- a/tests/plot_test.py
+++ b/tests/plot_test.py
@@ -173,6 +173,7 @@ class TestVariableSet:
             _ = vs.fakevariable
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestAppendColorbar:
     def test_append_colorbar_working(self):
         """Test that the routine works.
@@ -239,6 +240,7 @@ class TestStyleAxesKm:
         plt.close()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestFillSteps:
     """Test the `_fill_steps` function."""
 
@@ -726,6 +728,7 @@ class TestScaleLightness:
             assert darker_red[0] == pytest.approx(scale)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestShowHistograms:
     locs = [0.25, 1, 0.5, 4, 2]
     scales = [0.1, 0.25, 0.4, 0.5, 0.1]
@@ -787,6 +790,7 @@ class TestShowHistograms:
             show_histograms(*sets, sets=[0, 1], ax=ax)
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestAerialView:
     """These are just "does it work" tests."""
 
@@ -820,6 +824,7 @@ class TestAerialView:
         plt.close()
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
 class TestOverlaySparseArray:
     """These are just "does it work" tests."""
 

--- a/tests/section_test.py
+++ b/tests/section_test.py
@@ -655,6 +655,7 @@ class TestCubesWithManySections:
         t1, t2 = self.golfcube.sections["test1"], self.golfcube.sections["test2"]
         assert not (t1 is t2)
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show_trace_sections_multiple(self):
         self.golfcube.register_section("show_test1", StrikeSection(distance_idx=5))
         self.golfcube.register_section("show_test2", StrikeSection(distance_idx=50))
@@ -739,6 +740,14 @@ class TestSectionFromDataCubeNoStratigraphy:
         _v = self.golfcube_nostrat.sections["test"].variables
         assert len(_v) > 0
         assert isinstance(_v, list)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
+class TestSectionFromDataCubeNoStratigraphy:
+    """same as above class, but all "show" related tests"""
+
+    golfcube_nostrat = DataCube(golf_path)
+    golfcube_nostrat.register_section("test", StrikeSection(distance_idx=5))
 
     def test_nostrat_show_shaded_spacetime(self):
         self.golfcube_nostrat.sections["test"].show(

--- a/tests/section_test.py
+++ b/tests/section_test.py
@@ -1303,12 +1303,14 @@ class TestSectionsIntoMasks:
         assert _got.ndim == 1
         assert np.all(np.logical_or(_got == 1, _got == 0))
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show(self):
         mss = StrikeSection(self.EM, distance=500)
         fig, ax = plt.subplots()
         mss.show("mask", ax=ax)
         plt.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show_trace(self):
         mss = StrikeSection(self.EM, distance=500)
         fig, ax = plt.subplots()
@@ -1334,12 +1336,14 @@ class TestSectionsIntoPlans:
         assert _got.ndim == 1
         assert np.all(np.isfinite(_got))
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show(self):
         mss = StrikeSection(self.pl, distance=500)
         fig, ax = plt.subplots()
         mss.show("eta", ax=ax)
         plt.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show_trace(self):
         mss = StrikeSection(self.pl, distance=500)
         fig, ax = plt.subplots()
@@ -1364,12 +1368,14 @@ class TestSectionsIntoArrays:
         assert _got.ndim == 1
         assert np.all(np.logical_or(_got <= 1, _got >= 0))
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show(self):
         mss = StrikeSection(self.arr, distance=500)
         fig, ax = plt.subplots()
         mss.show("mask", ax=ax)
         plt.close()
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
     def test_show_trace(self):
         mss = StrikeSection(self.arr, distance=500)
         fig, ax = plt.subplots()

--- a/tests/section_test.py
+++ b/tests/section_test.py
@@ -886,6 +886,15 @@ class TestSectionFromDataCubeWithStratigraphy:
         assert sa["s"].shape == (self.golfcube.shape[2],)
         assert sa["s_sp"].shape == sa["z_sp"].shape
 
+
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
+class TestSectionFromDataCubeWithStratigraphy:
+    """same as above class, but all "show" related tests"""
+
+    golfcube = DataCube(golf_path)
+    golfcube.stratigraphy_from("eta", dz=0.1)
+    golfcube.register_section("test", StrikeSection(distance_idx=5))
+
     def test_withstrat_show_shaded_spacetime(self):
         self.golfcube.sections["test"].show("time", style="shaded", data="spacetime")
 
@@ -987,6 +996,16 @@ class TestSectionFromStratigraphyCube:
     def test_variables(self):
         assert isinstance(self.golfcube.sections["test"].variables, list)
         assert isinstance(self.sc8cube.sections["test"].variables, list)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="TCL install error common.")
+class TestSectionFromStratigraphyCube_SHOW:
+    """same as above class, but all "show" related tests"""
+
+    golfcube = DataCube(golf_path)
+    sc8cube = StratigraphyCube.from_DataCube(golfcube, dz=0.1)
+    golfcube.register_section("test", StrikeSection(distance_idx=5))
+    sc8cube.register_section("test", StrikeSection(distance_idx=5))
 
     def test_strat_show_noargs(self):
         self.sc8cube.sections["test"].show("time")

--- a/tests/section_test.py
+++ b/tests/section_test.py
@@ -1,3 +1,5 @@
+import sys
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -17,7 +17,6 @@ from sandplover.utils import runtime_from_log
 
 
 class TestNoStratigraphyError:
-
     def test_needs_obj_argument(self):
         with pytest.raises(TypeError):
             raise NoStratigraphyError()
@@ -34,7 +33,6 @@ class TestNoStratigraphyError:
 
 
 class TestLineToCells:
-
     def test_flat_inputs(self):
         x0, y0, x1, y1 = 10, 40, 50, 40
         ret1 = line_to_cells(np.array([[x0, y0], [x1, y1]]))


### PR DESCRIPTION
- skip one dimensional stratigraphy plotter on windows.

TCL error is common, related to some dependency not sandplover.