### PR TITLE
add new version of the golf dataset, sandsuet compliant.

### DIFF
--- a/sandplover/sample_data/__init__.py
+++ b/sandplover/sample_data/__init__.py
@@ -1,5 +1,6 @@
 from sandplover.sample_data.sample_data import aeolian
 from sandplover.sample_data.sample_data import golf
+from sandplover.sample_data.sample_data import golf_sandsuet
 from sandplover.sample_data.sample_data import landsat
 from sandplover.sample_data.sample_data import rcm8
 from sandplover.sample_data.sample_data import savi2020
@@ -8,6 +9,7 @@ from sandplover.sample_data.sample_data import xslope
 __all__ = (
     "aeolian",
     "golf",
+    "golf_sandsuet",
     "landsat",
     "rcm8",
     "savi2020",

--- a/sandplover/sample_data/registry.txt
+++ b/sandplover/sample_data/registry.txt
@@ -1,4 +1,5 @@
 golf.zip 4da329fa6ac7cac903d509a39b7921000cd987dc6889ccc14aeedfdf6f89e090 https://zenodo.org/record/5570962/files/golf.zip?download=1
+golf_sandsuet.zip md5:06a964e509ed9b1edf6b592769a18efd https://zenodo.org/record/19701176/files/golf.zip?download=1
 swanson_aeolian_expt1.nc 76001cd9e8b5570f6830a30e650b211180a2813618bc283f810b639b8b95e424 doi:10.6084/m9.figshare.17118827.v1/swanson_aeolian_expt1.nc
 LandsatEx.hdf5 56c5b6b3931b1a1182d9037742a0dc338e93261b1c073f66c2803886b4e2739f
 xslope.zip d2ffd09bbf05ae1087ec56f92a55752f9ecae25b5e463531260c294e354d7058 https://zenodo.org/record/6301362/files/xslope_demo_pyDeltaRCM.zip?download=1

--- a/sandplover/sample_data/sample_data.py
+++ b/sandplover/sample_data/sample_data.py
@@ -80,6 +80,58 @@ def golf():
     return DataCube(golf_path)
 
 
+def _get_golf_sandsuet_path():
+    unpack = pooch.Unzip()
+    fnames = REGISTRY.fetch("golf_sandsuet.zip", processor=unpack)
+    nc_bool = [os.path.splitext(fname)[1] == ".nc" for fname in fnames]
+    nc_idx = [i for i, b in enumerate(nc_bool) if b]
+    golf_path = fnames[nc_idx[0]]
+    return golf_path
+
+
+def golf_sandsuet():
+    """Golf Delta dataset in sandsuet format.
+
+    This is a synthetic delta dataset generated from the pyDeltaRCM numerical
+    model.
+
+    This model run was created to generate sample data.
+    Model was run on 04/22/2026, at Texas A&M University.
+
+    Run was computed with pyDeltaRCM v2.2.0. See log file for complete information
+    on system and model configuration.
+
+    Data available at Zenodo, version 1.2: 10.5281/zenodo.19701176.
+
+    Version history:
+    v1.2: 10.5281/zenodo.19701176
+    v1.1: 10.5281/zenodo.5570962
+    v1.0: 10.5281/zenodo.4456144
+
+    .. plot::
+
+        >>> import matplotlib.pyplot as plt
+        >>> import numpy as np
+        >>> from sandplover.sample_data.sample_data import golf
+
+        >>> golf = golf_sandsuet()
+        >>> nt = 5
+        >>> ts = np.linspace(0, golf["eta"].shape[0] - 1, num=nt, dtype=int)
+
+        >>> fig, ax = plt.subplots(1, nt, figsize=(12, 2))
+        >>> for i, t in enumerate(ts):
+        ...     _ = ax[i].imshow(golf["eta"][t, :, :], vmin=-2, vmax=0.5)
+        ...     _ = ax[i].set_title(f"t = {t}")
+        ...     _ = ax[i].axes.get_xaxis().set_ticks([])
+        ...     _ = ax[i].axes.get_yaxis().set_ticks([])
+        ...
+        >>> _ = ax[0].set_ylabel("dim1 direction")
+        >>> _ = ax[0].set_xlabel("dim2 direction")
+    """
+    golf_path = _get_golf_sandsuet_path()
+    return DataCube(golf_path)
+
+
 def _get_xslope_path():
     unpack = pooch.Unzip()
     fnames = REGISTRY.fetch("xslope.zip", processor=unpack)


### PR DESCRIPTION
add new version of the golf dataset, sandsuet compliant.

This is a new run of the :star2: reproducible :star2: pyDeltaRCM model with the same config, generating the exact same model result. The output file is in the new pyDeltaRCM output format though, which is sandsuet v1.0.0 compliant. 

Notably, this PR adds the new version as a sample dataset called `golf_sandsuet`, not overwriting the existing `golf` dataset. This is so that we can push forward development with a sandsuet dataset, but not break things in the process. Eventually, we will roll over the `golf_sandsuet` to be just the standard `golf` dataset, and then remove the `golf_sandsuet` as sample data.  