### PR TITLE
fix: read auxdata metadata groups

### DIFF
--- a/sandplover/cube.py
+++ b/sandplover/cube.py
@@ -119,9 +119,7 @@ class BaseCube(abc.ABC):
         """
         _, ext = os.path.splitext(data_path)
         if ext == ".nc":
-            self._dataio = NetCDFIO(
-                data_path, "netcdf", metadata_group=metadata_group
-            )
+            self._dataio = NetCDFIO(data_path, "netcdf", metadata_group=metadata_group)
         elif ext == ".hdf5":
             self._dataio = NetCDFIO(data_path, "hdf5", metadata_group=metadata_group)
         else:

--- a/sandplover/cube.py
+++ b/sandplover/cube.py
@@ -41,7 +41,9 @@ class BaseCube(abc.ABC):
 
     """
 
-    def __init__(self, data, read=(), varset=None, dimensions=None):
+    def __init__(
+        self, data, read=(), varset=None, dimensions=None, metadata_group=None
+    ):
         """Initialize the BaseCube.
 
         Parameters
@@ -65,11 +67,15 @@ class BaseCube(abc.ABC):
             A dictionary with names and coordinates for dimensions of the
             cube, if instantiating the cube from data loaded in memory
             in a dictionary.
+
+        metadata_group : `str`, optional
+            Name of a NetCDF group to use for metadata before falling back to
+            the default metadata group names.
         """
         if type(data) is str:
             # handle a path to netCDF file
             self._data_path = data
-            self._connect_to_file(data_path=data)
+            self._connect_to_file(data_path=data, metadata_group=metadata_group)
             self._read_meta_from_file()
         elif type(data) is dict:
             # handle a dict, arrays set up already, make an io class to wrap it
@@ -105,7 +111,7 @@ class BaseCube(abc.ABC):
         """
         ...
 
-    def _connect_to_file(self, data_path):
+    def _connect_to_file(self, data_path, metadata_group=None):
         """Connect to file.
 
         This method is used internally to send the ``data_path`` to the
@@ -113,9 +119,11 @@ class BaseCube(abc.ABC):
         """
         _, ext = os.path.splitext(data_path)
         if ext == ".nc":
-            self._dataio = NetCDFIO(data_path, "netcdf")
+            self._dataio = NetCDFIO(
+                data_path, "netcdf", metadata_group=metadata_group
+            )
         elif ext == ".hdf5":
-            self._dataio = NetCDFIO(data_path, "hdf5")
+            self._dataio = NetCDFIO(data_path, "hdf5", metadata_group=metadata_group)
         else:
             raise ValueError('Invalid file extension for "data_path": %s' % data_path)
 
@@ -657,7 +665,13 @@ class DataCube(BaseCube):
     """
 
     def __init__(
-        self, data, read=(), varset=None, stratigraphy_from=None, dimensions=None
+        self,
+        data,
+        read=(),
+        varset=None,
+        stratigraphy_from=None,
+        dimensions=None,
+        metadata_group=None,
     ):
         """Initialize the BaseCube.
 
@@ -691,8 +705,18 @@ class DataCube(BaseCube):
             A dictionary with names and coordinates for dimensions of the
             `DataCube`, if instantiating the cube from data loaded in memory
             in a dictionary.
+
+        metadata_group : `str`, optional
+            Name of a NetCDF group to use for metadata before falling back to
+            the default metadata group names.
         """
-        super().__init__(data, read, varset, dimensions=dimensions)
+        super().__init__(
+            data,
+            read,
+            varset,
+            dimensions=dimensions,
+            metadata_group=metadata_group,
+        )
 
         # Set up the time mesh (DataCube is t–x–y)
         _, self._T, _ = np.meshgrid(

--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -165,7 +165,7 @@ class NetCDFIO(FileIO):
     `docs <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html>`_.
     """
 
-    def __init__(self, data_path, io_type, write=False):
+    def __init__(self, data_path, io_type, write=False, metadata_group=None):
         """Initialize the NetCDFIO handler.
 
         Initialize a connection to a NetCDF file.
@@ -183,7 +183,12 @@ class NetCDFIO(FileIO):
             Whether to allow writing to an existing file. Set to False by
             default, if a file already exists at ``data_path``, writing is
             disabled, unless ``write`` is set to True.
+
+        metadata_group : `str`, optional
+            Name of a NetCDF group to use for metadata before falling back to
+            the default metadata group names.
         """
+        self.metadata_group = metadata_group
 
         super().__init__(data_path=data_path, io_type=io_type, write=write)
 
@@ -259,17 +264,26 @@ class NetCDFIO(FileIO):
             # warn('Coordinates for "time", and set("x", "y") not provided in the \
             #       given data file.', UserWarning)
 
-        # check for a matching meta field, and set it accordingly
-        if "/metadata" in self.dataset.groups:
-            self.meta = self.dataset["metadata"]
-        elif "/meta" in self.dataset.groups:
-            self.meta = self.dataset["meta"]
-            warnings.warn(
-                "Metadata found with group name `meta`, but this specification "
-                "is deprecated. Change group name to `metadata`.",
-                UserWarning,
-                stacklevel=2,
-            )
+        # check for a matching metadata group, and set it accordingly
+        metadata_groups = [self.metadata_group, "metadata", "auxdata", "meta"]
+        for metadata_group in metadata_groups:
+            if metadata_group is None:
+                continue
+
+            metadata_group = metadata_group.strip("/")
+            if f"/{metadata_group}" not in self.dataset.groups:
+                continue
+
+            self.meta = self.dataset[metadata_group]
+            if metadata_group == "meta":
+                warnings.warn(
+                    "Metadata found with group name `meta`, but this "
+                    "specification is deprecated. Change group name to "
+                    "`metadata`.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            break
         else:
             warnings.warn(
                 "No associated metadata was found in the given data file.",

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -24,6 +24,42 @@ def empty_netcdf_file(tmp_path):
     return p
 
 
+def _netcdf_file_with_metadata_group(tmp_path, group_name):
+    """Create a NetCDF file with coordinates, data, and a metadata group."""
+    p = tmp_path / f"{group_name}.nc"
+    f = netCDF4.Dataset(p, "w", format="NETCDF4")
+    f.createDimension("time", 2)
+    f.createDimension("x", 3)
+    f.createDimension("y", 4)
+
+    time = f.createVariable("time", "f8", ("time",))
+    x = f.createVariable("x", "f8", ("x",))
+    y = f.createVariable("y", "f8", ("y",))
+    eta = f.createVariable("eta", "f8", ("time", "x", "y"))
+    time[:] = np.arange(2)
+    x[:] = np.arange(3)
+    y[:] = np.arange(4)
+    eta[:] = np.ones((2, 3, 4))
+
+    meta = f.createGroup(group_name)
+    meta.createVariable("H_SL", "f8")
+    meta["H_SL"][:] = 1.5
+    f.close()
+    return p
+
+
+@pytest.fixture
+def netcdf_file_with_auxdata(tmp_path):
+    """Create NetCDF4 file with pyDeltaRCM-style auxdata metadata."""
+    return _netcdf_file_with_metadata_group(tmp_path, "auxdata")
+
+
+@pytest.fixture
+def netcdf_file_with_run_metadata(tmp_path):
+    """Create NetCDF4 file with a custom metadata group."""
+    return _netcdf_file_with_metadata_group(tmp_path, "run_metadata")
+
+
 @pytest.fixture
 def empty_txt_file(tmp_path):
     """Create a dummy text file."""
@@ -152,6 +188,18 @@ def test_netcdf_no_metadata():
     # works fine, because there is no `connect` call in io init
     netcdf_io = NetCDFIO(golf_path, "netcdf")
     assert len(netcdf_io._in_memory_data) == 0
+
+
+def test_netcdf_auxdata_metadata_group(netcdf_file_with_auxdata):
+    netcdf_io = NetCDFIO(netcdf_file_with_auxdata, "netcdf")
+    assert netcdf_io.meta["H_SL"].item() == 1.5
+
+
+def test_netcdf_custom_metadata_group(netcdf_file_with_run_metadata):
+    netcdf_io = NetCDFIO(
+        netcdf_file_with_run_metadata, "netcdf", metadata_group="run_metadata"
+    )
+    assert netcdf_io.meta["H_SL"].item() == 1.5
 
 
 class TestDictionaryIO:


### PR DESCRIPTION
Closes #243.

Summary:
- include `auxdata` in the default NetCDF metadata group lookup after `metadata`
- add a `metadata_group` override for `NetCDFIO` and path-based `DataCube` loading
- add generated NetCDF regression coverage for `auxdata` and a custom metadata group

Validation:
- `.venv-io/bin/python -m pytest tests/io_test.py -q` (24 passed, 2 xpassed, 8 warnings)
- direct `DataCube(str(path), metadata_group="run_metadata")` smoke script passed
- `python3 -m py_compile sandplover/io.py sandplover/cube.py tests/io_test.py`
- `.venv-io/bin/python -m flake8 --config setup.cfg sandplover/io.py sandplover/cube.py tests/io_test.py`
- `git diff --check`
- `gitleaks protect --staged --redact --verbose` (no leaks found)

Not run:
- full `uv run --extra testing ...` environment; local dependency setup failed before tests on native `llvmlite`/`netCDF4` build requirements, so I used the minimal IO test environment above.
