### PR TITLE
Bugfix `.extent`

### DIFF
--- a/sandplover/cube.py
+++ b/sandplover/cube.py
@@ -398,6 +398,7 @@ class BaseCube(abc.ABC):
             self.dim1_coords[-1] + self.dim1_coords[1],  # dim0, end + dx
             self.dim1_coords[0],
         ]  # dim0, 0
+        _extent = [float(e) for e in _extent]  # quickfix list comp
         return _extent
 
     @property
@@ -407,7 +408,7 @@ class BaseCube(abc.ABC):
         limits of the dim1 by dim2 plane,
         """
         _extent = self.extent
-        return [_extent[:2], _extent[3], _extent[2]]
+        return [*_extent[:2], _extent[3], _extent[2]]
 
     @property
     def extent_zeros(self):

--- a/tests/cube_test.py
+++ b/tests/cube_test.py
@@ -303,6 +303,18 @@ class TestDataCubeNoStratigraphy:
         with pytest.raises(TypeError, match=r"`name` was not .*"):
             golf.show_planform(1, "two")
 
+    def test_extent(self):
+        golf = DataCube(golf_path)
+        assert len(golf.extent) == 4
+        assert isinstance(golf.extent, list)
+        assert isinstance(golf.extent[0], float)
+
+    def test_extent_flipud(self):
+        golf = DataCube(golf_path)
+        assert len(golf.extent_flipud) == 4
+        assert isinstance(golf.extent_flipud, list)
+        assert isinstance(golf.extent_flipud[0], float)
+
 
 class TestDataCubeWithStratigraphy:
     # test setting all the properties / attributes


### PR DESCRIPTION
bugfixes for `cube.extent` and `cube.extent_flipud`. Something changed in the xarray or mpl at some point with returning or accepting data types here and these no longer worked. Adds basic test for types so should be stable. 