### PR TITLE
change `meta` to `aux` and allow it to be specified during instantiation

### DIFF
--- a/sandplover/cube.py
+++ b/sandplover/cube.py
@@ -41,7 +41,7 @@ class BaseCube(abc.ABC):
 
     """
 
-    def __init__(self, data, read=(), varset=None, dimensions=None):
+    def __init__(self, data, auxdata=None, read=(), varset=None, dimensions=None):
         """Initialize the BaseCube.
 
         Parameters
@@ -52,6 +52,10 @@ class BaseCube(abc.ABC):
             output from the pyDeltaRCM model. Alternatively, pass a
             :obj:`dict` with keys indicating variable names, and values with
             corresponding t-x-y `ndarray` of data.
+
+        auxdata : :obj:`str`, optional
+            The information `data` is searched for a key matching the string
+            `auxdata`, and if found, this key is assigned to `cube.aux`.
 
         read : :obj:`bool`, optional
             Which variables to read from dataset into memory. Special option
@@ -69,7 +73,7 @@ class BaseCube(abc.ABC):
         if type(data) is str:
             # handle a path to netCDF file
             self._data_path = data
-            self._connect_to_file(data_path=data)
+            self._connect_to_file(data_path=data, auxdata_path=auxdata)
             self._read_meta_from_file()
         elif type(data) is dict:
             # handle a dict, arrays set up already, make an io class to wrap it
@@ -109,7 +113,7 @@ class BaseCube(abc.ABC):
         """
         ...
 
-    def _connect_to_file(self, data_path):
+    def _connect_to_file(self, data_path, auxdata_path):
         """Connect to file.
 
         This method is used internally to send the ``data_path`` to the
@@ -117,9 +121,9 @@ class BaseCube(abc.ABC):
         """
         _, ext = os.path.splitext(data_path)
         if ext == ".nc":
-            self._dataio = NetCDFIO(data_path, "netcdf")
+            self._dataio = NetCDFIO(data_path, auxdata_path, "netcdf")
         elif ext == ".hdf5":
-            self._dataio = NetCDFIO(data_path, "hdf5")
+            self._dataio = NetCDFIO(data_path, auxdata_path, "hdf5")
         else:
             raise ValueError('Invalid file extension for "data_path": %s' % data_path)
 
@@ -210,7 +214,22 @@ class BaseCube(abc.ABC):
 
     @property
     def meta(self):
-        return self._dataio.meta
+        warnings.warn(
+            DeprecationWarning(
+                "The `meta` property of the Cube has been replaced by the "
+                "`aux` property, and will be removed in a future release."
+            )
+        )
+        return self._dataio.aux
+
+    @property
+    def aux(self):
+        return self._dataio.aux
+
+    @property
+    def auxdata(self):
+        """simple alias"""
+        return self._dataio.aux
 
     @property
     def varset(self):
@@ -673,7 +692,13 @@ class DataCube(BaseCube):
     """
 
     def __init__(
-        self, data, read=(), varset=None, stratigraphy_from=None, dimensions=None
+        self,
+        data,
+        auxdata=None,
+        read=(),
+        varset=None,
+        stratigraphy_from=None,
+        dimensions=None,
     ):
         """Initialize the BaseCube.
 
@@ -708,7 +733,7 @@ class DataCube(BaseCube):
             `DataCube`, if instantiating the cube from data loaded in memory
             in a dictionary.
         """
-        super().__init__(data, read, varset, dimensions=dimensions)
+        super().__init__(data, auxdata, read, varset, dimensions=dimensions)
 
         # Set up the time mesh (DataCube is t–x–y)
         _, self._T, _ = np.meshgrid(
@@ -923,6 +948,7 @@ class StratigraphyCube(BaseCube):
     def __init__(
         self,
         data,
+        auxdata=None,
         read=(),
         varset=None,
         stratigraphy_from=None,
@@ -954,7 +980,7 @@ class StratigraphyCube(BaseCube):
             to style this cube similarly to another cube. If no argument is
             supplied, a new default VariableSet instance is created.
         """
-        super().__init__(data, read, varset)
+        super().__init__(data, auxdata, read, varset)
         if isinstance(data, str):
             raise NotImplementedError("Precomputed NetCDF?")
         elif isinstance(data, np.ndarray):

--- a/sandplover/cube.py
+++ b/sandplover/cube.py
@@ -73,18 +73,18 @@ class BaseCube(abc.ABC):
         if type(data) is str:
             # handle a path to netCDF file
             self._data_path = data
-            self._connect_to_file(data_path=data, auxdata_path=auxdata)
-            self._read_meta_from_file()
+            self._dataio = NetCDFIO(data_path=data, auxdata_path=auxdata)
+            self._read_coords_dims_variables_from_dataio()
         elif type(data) is dict:
             # handle a dict, arrays set up already, make an io class to wrap it
             self._data_path = None
             self._dataio = DictionaryIO(data, dimensions=dimensions)
-            self._read_meta_from_file()
+            self._read_coords_dims_variables_from_dataio()
         elif isinstance(data, DataCube):
             # handle initializing one cube type from another
             self._data_path = data.data_path
             self._dataio = data._dataio
-            self._read_meta_from_file()
+            self._read_coords_dims_variables_from_dataio()
         else:
             raise TypeError('Invalid type for "data": %s' % type(data))
 
@@ -113,21 +113,7 @@ class BaseCube(abc.ABC):
         """
         ...
 
-    def _connect_to_file(self, data_path, auxdata_path):
-        """Connect to file.
-
-        This method is used internally to send the ``data_path`` to the
-        correct IO handler.
-        """
-        _, ext = os.path.splitext(data_path)
-        if ext == ".nc":
-            self._dataio = NetCDFIO(data_path, auxdata_path, "netcdf")
-        elif ext == ".hdf5":
-            self._dataio = NetCDFIO(data_path, auxdata_path, "hdf5")
-        else:
-            raise ValueError('Invalid file extension for "data_path": %s' % data_path)
-
-    def _read_meta_from_file(self):
+    def _read_coords_dims_variables_from_dataio(self):
         """Read metadata information from variables in file.
 
         Robustly determine dimension names by preferring explicitly

--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -65,7 +65,7 @@ class FileIO(BaseIO):
     `read`, and `write`, and the  `keys` attribute.
     """
 
-    def __init__(self, data_path, auxdata_path, io_type, write=False):
+    def __init__(self, data_path, auxdata_path, write=False):
         """Initialize a file IO handler.
 
         Initialize a connection to a NetCDF file.
@@ -84,11 +84,10 @@ class FileIO(BaseIO):
             default, if a file already exists at ``data_path``, writing is
             disabled, unless ``write`` is set to True.
         """
-        super().__init__(io_type=io_type)
+        super().__init__(io_type="file")
 
         self.data_path = data_path
         self.auxdata_path = auxdata_path
-        self.io_type = io_type
 
         self.write = write
 
@@ -179,7 +178,7 @@ class NetCDFIO(FileIO):
     `docs <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html>`_.
     """
 
-    def __init__(self, data_path, auxdata_path, io_type, write=False):
+    def __init__(self, data_path, auxdata_path, engine=None, write=False):
         """Initialize the NetCDFIO handler.
 
         Initialize a connection to a NetCDF file.
@@ -189,18 +188,32 @@ class NetCDFIO(FileIO):
         data_path : `str`
             Path to file to read or write to.
 
-        io_type : `str`
-            Stores the type of output file loaded, either a netCDF4 file,
-            'netcdf' or an HDF5 file, 'hdf5'.
+        engine : `str`, optional
+            Engine used to open the file with xarray. Default is None, which
+            will lead to trying to infer from file extension. If no inference
+            can be made, we pass no engine during loading and allow xarray to
+            attempt to determine the file type. For a netCDF4 file use 'netcdf4' or
+            for an HDF5 file use 'h5netcdf', or any other valid engine for xarray.
 
         write : `bool`, optional
             Whether to allow writing to an existing file. Set to False by
             default, if a file already exists at ``data_path``, writing is
             disabled, unless ``write`` is set to True.
         """
-        super().__init__(
-            data_path=data_path, auxdata_path=auxdata_path, io_type=io_type, write=write
-        )
+        # set engine used to open the file
+        if engine is not None:
+            self._engine = engine
+        else:
+            # attempt to guess
+            _, ext = os.path.splitext(data_path)
+            if ext == ".nc":
+                self._engine = "netcdf4"
+            elif ext == ".hdf5":
+                self._engine = "h5netcdf"
+            else:
+                self._engine = None  # let xarray figure it out
+
+        super().__init__(data_path=data_path, auxdata_path=auxdata_path, write=write)
 
         self._in_memory_data = {}
 
@@ -220,17 +233,9 @@ class NetCDFIO(FileIO):
             _tempdataset = netCDF4.Dataset(self.data_path, "w", format="NETCDF4")
             _tempdataset.close()
 
-        _ext = os.path.splitext(self.data_path)[-1]
-        if _ext == ".nc":
-            _engine = "netcdf4"
-        elif _ext == ".hdf5":
-            _engine = "h5netcdf"
-        else:
-            _engine = None  # not sure, let xarray figure it out
-
         try:
             # open the dataset
-            _dataset = xr.open_datatree(self.data_path, engine=_engine)
+            _dataset = xr.open_datatree(self.data_path, engine=self._engine)
         except Exception as e:
             raise TypeError(
                 f"Could not open dataset, raising error: {e}.\n\n"

--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -45,13 +45,13 @@ class BaseIO(abc.ABC):
 
     @property
     def aux(self):
-        self._aux
+        return self._aux
 
     @property
     def meta(self):
         """alias for backwards compatability"""
         # will be removed in future release.
-        self._aux
+        return self._aux
 
 
 class FileIO(BaseIO):
@@ -84,6 +84,8 @@ class FileIO(BaseIO):
             default, if a file already exists at ``data_path``, writing is
             disabled, unless ``write`` is set to True.
         """
+        super().__init__(io_type=io_type)
+
         self.data_path = data_path
         self.auxdata_path = auxdata_path
         self.io_type = io_type
@@ -94,8 +96,6 @@ class FileIO(BaseIO):
 
         self.get_known_coords()
         self.get_known_variables()
-
-        super().__init__(io_type=io_type)
 
     @property
     def data_path(self):
@@ -300,7 +300,9 @@ class NetCDFIO(FileIO):
                         stacklevel=2,
                     )
                 match = next(iter(matched))[1:]  # get the match and drop leading /
+                self.dataset[match]
                 self._aux = self.dataset[match]
+                print(self.aux)
 
     def get_known_variables(self):
         """List known variables.

--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -30,6 +30,7 @@ class BaseIO(abc.ABC):
     def __init__(self, io_type):
         """Initialize the base IO."""
         self.io_type = io_type
+        self._aux = None  # default None
 
     @abc.abstractmethod
     def __getitem__(self):
@@ -41,6 +42,16 @@ class BaseIO(abc.ABC):
     def keys(self):
         """Should link to all key _names_ stored in file."""
         return
+
+    @property
+    def aux(self):
+        self._aux
+
+    @property
+    def meta(self):
+        """alias for backwards compatability"""
+        # will be removed in future release.
+        self._aux
 
 
 class FileIO(BaseIO):
@@ -54,7 +65,7 @@ class FileIO(BaseIO):
     `read`, and `write`, and the  `keys` attribute.
     """
 
-    def __init__(self, data_path, io_type, write=False):
+    def __init__(self, data_path, auxdata_path, io_type, write=False):
         """Initialize a file IO handler.
 
         Initialize a connection to a NetCDF file.
@@ -74,7 +85,9 @@ class FileIO(BaseIO):
             disabled, unless ``write`` is set to True.
         """
         self.data_path = data_path
+        self.auxdata_path = auxdata_path
         self.io_type = io_type
+
         self.write = write
 
         self.connect()
@@ -166,7 +179,7 @@ class NetCDFIO(FileIO):
     `docs <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html>`_.
     """
 
-    def __init__(self, data_path, io_type, write=False):
+    def __init__(self, data_path, auxdata_path, io_type, write=False):
         """Initialize the NetCDFIO handler.
 
         Initialize a connection to a NetCDF file.
@@ -185,8 +198,9 @@ class NetCDFIO(FileIO):
             default, if a file already exists at ``data_path``, writing is
             disabled, unless ``write`` is set to True.
         """
-
-        super().__init__(data_path=data_path, io_type=io_type, write=write)
+        super().__init__(
+            data_path=data_path, auxdata_path=auxdata_path, io_type=io_type, write=write
+        )
 
         self._in_memory_data = {}
 
@@ -260,24 +274,33 @@ class NetCDFIO(FileIO):
             # warn('Coordinates for "time", and set("x", "y") not provided in the \
             #       given data file.', UserWarning)
 
-        # check for a matching meta field, and set it accordingly
-        if "/metadata" in self.dataset.groups:
-            self.meta = self.dataset["metadata"]
-        elif "/meta" in self.dataset.groups:
-            self.meta = self.dataset["meta"]
-            warnings.warn(
-                "Metadata found with group name `meta`, but this specification "
-                "is deprecated. Change group name to `metadata`.",
-                UserWarning,
-                stacklevel=2,
-            )
+        # if something was specified for auxdata, set it accordingly
+        if not self.auxdata_path is None:
+            self._aux = self.dataset[self.auxdata_path]
+        # otherwise nothing was passed and we may be able to detect it *for now*
+        # for backwards compatability,  but this will be deprecated in the
+        # future, requiring explicit specification of the aux group.
+
         else:
-            warnings.warn(
-                "No associated metadata was found in the given data file.",
-                UserWarning,
-                stacklevel=2,
-            )
-            self.meta = None
+            _known = ["/meta", "/metadata", "/auxdata"]
+            matched = set(_known).intersection(self.dataset.groups)
+            if any(matched):
+                warnings.warn(
+                    "Group with recognized name found for auxiliary data, "
+                    "but this group was not passed as `auxdata` during instantiation. "
+                    "Autodetecting auxiliary data is deprecated and may be removed "
+                    "in the future.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                if len(matched) > 1:
+                    warnings.warn(
+                        "Multiple groups recognized. Using first in set, which may lead to inconsistent behavior.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                match = next(iter(matched))[1:]  # get the match and drop leading /
+                self._aux = self.dataset[match]
 
     def get_known_variables(self):
         """List known variables.

--- a/sandplover/io.py
+++ b/sandplover/io.py
@@ -178,7 +178,7 @@ class NetCDFIO(FileIO):
     `docs <https://www.unidata.ucar.edu/software/netcdf/docs/faq.html>`_.
     """
 
-    def __init__(self, data_path, auxdata_path, engine=None, write=False):
+    def __init__(self, data_path, auxdata_path=None, engine=None, write=False):
         """Initialize the NetCDFIO handler.
 
         Initialize a connection to a NetCDF file.
@@ -188,12 +188,25 @@ class NetCDFIO(FileIO):
         data_path : `str`
             Path to file to read or write to.
 
+        auxdata_path : `str`, optional
+            Path to auxilliary data that exist in the file. This is most
+            commonly the name of a group within the file. Default is None, and
+            no auxilliary data is assigned.
+
+        .. warning::
+
+            Deprecation: If `auxdata_path=None`, we will for a few minor
+            versions, search the file for groups that match commonly used
+            names for auxilliary data and will assign this group if found.
+            This will issue a warning and will be removed in a future release.
+
         engine : `str`, optional
             Engine used to open the file with xarray. Default is None, which
             will lead to trying to infer from file extension. If no inference
             can be made, we pass no engine during loading and allow xarray to
-            attempt to determine the file type. For a netCDF4 file use 'netcdf4' or
-            for an HDF5 file use 'h5netcdf', or any other valid engine for xarray.
+            attempt to determine the file type. For a netCDF4 file use 'netcdf4'
+            or for an HDF5 file use 'h5netcdf', or any other valid engine for
+            xarray.
 
         write : `bool`, optional
             Whether to allow writing to an existing file. Set to False by

--- a/sandplover/sample_data/sample_data.py
+++ b/sandplover/sample_data/sample_data.py
@@ -77,7 +77,7 @@ def golf():
         >>> _ = ax[0].set_xlabel("dim2 direction")
     """
     golf_path = _get_golf_path()
-    return DataCube(golf_path)
+    return DataCube(golf_path, auxdata="meta")
 
 
 def _get_golf_sandsuet_path():
@@ -129,7 +129,7 @@ def golf_sandsuet():
         >>> _ = ax[0].set_xlabel("dim2 direction")
     """
     golf_path = _get_golf_sandsuet_path()
-    return DataCube(golf_path)
+    return DataCube(golf_path, auxdata="auxdata")
 
 
 def _get_xslope_path():

--- a/tests/cube_test.py
+++ b/tests/cube_test.py
@@ -10,6 +10,7 @@ from sandplover.plan import BasePlanform
 from sandplover.plan import Planform
 from sandplover.plot import VariableSet
 from sandplover.sample_data.sample_data import _get_golf_path
+from sandplover.sample_data.sample_data import _get_aeolian_path
 from sandplover.sample_data.sample_data import _get_landsat_path
 from sandplover.sample_data.sample_data import _get_rcm8_path
 from sandplover.sample_data.sample_data import rcm8
@@ -18,7 +19,26 @@ from sandplover.section import StrikeSection
 from sandplover.utils import NoStratigraphyError
 
 golf_path = _get_golf_path()
+aeolian_path = _get_aeolian_path()
 hdf_path = _get_landsat_path()
+
+
+class TestDataCubeAuxdata:
+
+    def test_initializing_without_argument_warns_autodetect(self):
+        with pytest.warns(UserWarning, match=r"Autodetecting"):
+            golf = DataCube(golf_path)
+        assert golf.aux is not None
+
+    def test_initializing_without_argument_nc(self):
+        # cube = DataCube(tdb12_path)
+        # assert cube.aux is None
+        ## NO SAMPLE DATA AVAILABLE TO TEST
+        pass
+
+    def test_initializing_with_argument(self):
+        golf = DataCube(golf_path, auxdata="meta")
+        assert golf.aux is not None
 
 
 class TestDataCubeNoStratigraphy:
@@ -745,8 +765,8 @@ class TestReadMetaFallbacks:
 
 class TestLandsatCube:
     def test_init_cube_from_path_hdf5(self):
-        with pytest.warns(UserWarning, match=r"No associated metadata"):
-            hdfcube = DataCube(hdf_path)
+        # with pytest.warns(UserWarning, match=r"Group with.*"):
+        hdfcube = DataCube(hdf_path)
         assert hdfcube._data_path == hdf_path
         assert hdfcube.dataio.io_type == "hdf5"
         assert hdfcube._planform_set == {}
@@ -754,8 +774,8 @@ class TestLandsatCube:
         assert type(hdfcube.varset) is VariableSet
 
     def test_read_Blue_intomemory(self):
-        with pytest.warns(UserWarning, match=r"No associated metadata"):
-            landsatcube = DataCube(hdf_path)
+        # with pytest.warns(UserWarning, match=r"Group with.*"):
+        landsatcube = DataCube(hdf_path)
         assert landsatcube._dataio._in_memory_data == {}
         assert landsatcube.variables == ["Blue", "Green", "NIR", "Red"]
         assert len(landsatcube.variables) == 4
@@ -764,8 +784,8 @@ class TestLandsatCube:
         assert len(landsatcube.dataio._in_memory_data) == 1
 
     def test_read_all_intomemory(self):
-        with pytest.warns(UserWarning, match=r"No associated metadata"):
-            landsatcube = DataCube(hdf_path)
+        # with pytest.warns(UserWarning, match=r"Group with.*"):
+        landsatcube = DataCube(hdf_path)
         assert landsatcube.variables == ["Blue", "Green", "NIR", "Red"]
         assert len(landsatcube.variables) == 4
 
@@ -773,13 +793,13 @@ class TestLandsatCube:
         assert len(landsatcube.dataio._in_memory_data) == 4
 
     def test_read_invalid(self):
-        with pytest.warns(UserWarning, match=r"No associated metadata"):
-            landsatcube = DataCube(hdf_path)
+        # with pytest.warns(UserWarning, match=r"Group with.*"):
+        landsatcube = DataCube(hdf_path)
         with pytest.raises(TypeError):
             landsatcube.read(5)
 
     def test_get_coords(self):
-        with pytest.warns(UserWarning, match=r"No associated metadata"):
-            landsatcube = DataCube(hdf_path)
+        # with pytest.warns(UserWarning, match=r"Group with.*"):
+        landsatcube = DataCube(hdf_path)
         assert landsatcube.coords == ["time", "x", "y"]
         assert landsatcube._coords == ["time", "x", "y"]

--- a/tests/cube_test.py
+++ b/tests/cube_test.py
@@ -1,5 +1,6 @@
 import unittest.mock as mock
 
+
 import numpy as np
 import pytest
 import xarray as xr
@@ -23,25 +24,32 @@ aeolian_path = _get_aeolian_path()
 hdf_path = _get_landsat_path()
 
 
-class TestDataCubeAuxdata:
+@mock.patch("sandplover.cube.NetCDFIO")
+class TestDataCubeInitializationArguments:
 
-    def test_initializing_without_argument_warns_autodetect(self):
-        with pytest.warns(UserWarning, match=r"Autodetecting"):
-            golf = DataCube(golf_path)
-        assert golf.aux is not None
-
-    def test_initializing_without_argument_nc(self):
+    def test_initializing_without_argument_nc(self, mock_netcdfio):
         # cube = DataCube(tdb12_path)
         # assert cube.aux is None
         ## NO SAMPLE DATA AVAILABLE TO TEST
         pass
 
-    def test_initializing_with_argument(self):
-        golf = DataCube(golf_path, auxdata="meta")
-        assert golf.aux is not None
+    def test_initializing_without_argument_warns_autodetect(self, mock_netcdfio):
+        with pytest.raises(Exception):
+            # the functions following instantiation will error out, so just
+            # check that argument was passed to io
+            golf = DataCube(golf_path)
+        mock_netcdfio.assert_called_once_with(data_path=mock.ANY, auxdata_path=None)
+
+    def test_initializing_with_argument(self, mock_netcdfio):
+        with pytest.raises(Exception):
+            # the functions following instantiation will error out, so just
+            # check that argument was passed to io
+            golf = DataCube(golf_path, auxdata="meta")
+        mock_netcdfio.assert_called_once_with(data_path=mock.ANY, auxdata_path="meta")
 
 
 class TestDataCubeNoStratigraphy:
+
     def test_init_cube_from_path_rcm8(self):
         golf = DataCube(golf_path)
         assert golf._data_path == golf_path

--- a/tests/cube_test.py
+++ b/tests/cube_test.py
@@ -11,6 +11,7 @@ from sandplover.plan import BasePlanform
 from sandplover.plan import Planform
 from sandplover.plot import VariableSet
 from sandplover.sample_data.sample_data import _get_golf_path
+from sandplover.sample_data.sample_data import _get_golf_sandsuet_path
 from sandplover.sample_data.sample_data import _get_aeolian_path
 from sandplover.sample_data.sample_data import _get_landsat_path
 from sandplover.sample_data.sample_data import _get_rcm8_path
@@ -19,7 +20,7 @@ from sandplover.section import BaseSection
 from sandplover.section import StrikeSection
 from sandplover.utils import NoStratigraphyError
 
-golf_path = _get_golf_path()
+golf_path = _get_golf_sandsuet_path()
 aeolian_path = _get_aeolian_path()
 hdf_path = _get_landsat_path()
 

--- a/tests/cube_test.py
+++ b/tests/cube_test.py
@@ -50,10 +50,10 @@ class TestDataCubeInitializationArguments:
 
 class TestDataCubeNoStratigraphy:
 
-    def test_init_cube_from_path_rcm8(self):
+    def test_init_cube_from_path_golf(self):
         golf = DataCube(golf_path)
         assert golf._data_path == golf_path
-        assert golf.dataio.io_type == "netcdf"
+        assert golf.dataio.io_type == "file"
         assert golf._planform_set == {}
         assert golf._section_set == {}
         assert type(golf.varset) is VariableSet
@@ -67,7 +67,7 @@ class TestDataCubeNoStratigraphy:
             _ = DataCube("./nonexistent/path.nc")
 
     def test_error_init_bad_extension(self):
-        with pytest.raises(ValueError):
+        with pytest.raises(FileNotFoundError):
             _ = DataCube("./nonexistent/path.doc")
 
     def test_error_init_bad_type(self):
@@ -571,8 +571,9 @@ class TestCubesFromDictionary:
         fixeddatacube = DataCube(golf_path)
         eta_data = fixeddatacube["eta"][:30, :, :]
         dict_cube = DataCube({"eta": eta_data})
-        with pytest.raises(AttributeError):
-            dict_cube.meta
+        assert dict_cube.aux is None
+        with pytest.warns(DeprecationWarning):
+            assert dict_cube.meta is None  # to be deprecated
 
     @pytest.mark.parametrize(
         "order",
@@ -607,7 +608,7 @@ class TestCubesFromDictionary:
 
 class TestReadMetaFallbacks:
     class FakeIO:
-        """Very small IO stub exposing only what _read_meta_from_file uses."""
+        """Very small IO stub exposing only what _read_coords_dims_variables_from_dataio uses."""
 
         def __init__(
             self,
@@ -699,7 +700,7 @@ class TestReadMetaFallbacks:
 
         # Swap in the stub IO and re-run metadata discovery
         cube._dataio = fake_io
-        cube._read_meta_from_file()
+        cube._read_coords_dims_variables_from_dataio()
 
         # Indices/coords should come from the stubbed 1-D arrays
         assert np.array_equal(cube._dim0_coords, np.arange(t))
@@ -716,7 +717,7 @@ class TestReadMetaFallbacks:
         cube = self._fresh_cube(t, y, x)
 
         cube._dataio = fake_io
-        cube._read_meta_from_file()
+        cube._read_coords_dims_variables_from_dataio()
 
         # Collapsed coords must match the original 1-D ranges that produced the mesh
         assert np.array_equal(cube._dim1_coords, np.arange(y))  # from [:, 0]
@@ -732,7 +733,7 @@ class TestReadMetaFallbacks:
             TypeError,
             match=r"(?i)shape of coordinate array was not 1[-\s]?d or 2[-\s]?d",
         ):
-            cube._read_meta_from_file()
+            cube._read_coords_dims_variables_from_dataio()
 
     def test_scan_3d_var_handles_getitem_error(self):
         """Cover the `except: continue` branch while scanning known_variables."""
@@ -747,7 +748,7 @@ class TestReadMetaFallbacks:
             three_d={"temperature"},  # second var is the 3-D one
         )
         cube._dataio = fake_io
-        cube._read_meta_from_file()
+        cube._read_coords_dims_variables_from_dataio()
 
         # Confirm we built coords successfully from the stub
         assert np.array_equal(cube._dim0_coords, np.arange(t))
@@ -768,7 +769,7 @@ class TestReadMetaFallbacks:
         )
         cube._dataio = fake_io
         with pytest.raises(ValueError, match=r"Could not infer 3-D dimensions"):
-            cube._read_meta_from_file()
+            cube._read_coords_dims_variables_from_dataio()
 
 
 class TestLandsatCube:

--- a/tests/io_test.py
+++ b/tests/io_test.py
@@ -32,126 +32,121 @@ def empty_txt_file(tmp_path):
     return p
 
 
-def test_netcdf_io_init():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    assert netcdf_io.io_type == "netcdf"
-    assert len(netcdf_io._in_memory_data) == 0
+class TestNetCDFIO:
+    def test_netcdf_io_init(self):
+        netcdf_io = NetCDFIO(golf_path)
+        assert netcdf_io.io_type == "file"
+        assert netcdf_io._engine == "netcdf4"
+        assert len(netcdf_io._in_memory_data) == 0
 
+    def test_netcdf_io_keys(self):
+        netcdf_io = NetCDFIO(golf_path)
+        assert len(netcdf_io.keys) > 3
 
-def test_netcdf_io_keys():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    assert len(netcdf_io.keys) > 3
+    def test_netcdf_io_nomemory(self):
+        netcdf_io = NetCDFIO(golf_path)
+        dataset_size = sys.getsizeof(netcdf_io.dataset)
+        inmemory_size = sys.getsizeof(netcdf_io._in_memory_data)
 
+        var = "velocity"
+        # slice the dataset directly
+        velocity_arr = netcdf_io.dataset[var].data[:, 10, :]
+        assert len(velocity_arr.shape) == 2
+        assert type(velocity_arr) is np.ndarray
 
-def test_netcdf_io_nomemory():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    dataset_size = sys.getsizeof(netcdf_io.dataset)
-    inmemory_size = sys.getsizeof(netcdf_io._in_memory_data)
+        dataset_size_after = sys.getsizeof(netcdf_io.dataset)
+        inmemory_size_after = sys.getsizeof(netcdf_io._in_memory_data)
 
-    var = "velocity"
-    # slice the dataset directly
-    velocity_arr = netcdf_io.dataset[var].data[:, 10, :]
-    assert len(velocity_arr.shape) == 2
-    assert type(velocity_arr) is np.ndarray
+        assert dataset_size == dataset_size_after
+        assert inmemory_size == inmemory_size_after
 
-    dataset_size_after = sys.getsizeof(netcdf_io.dataset)
-    inmemory_size_after = sys.getsizeof(netcdf_io._in_memory_data)
+    @pytest.mark.xfail()
+    def test_netcdf_io_intomemory_direct(self):
+        netcdf_io = NetCDFIO(golf_path, "netcdf")
+        dataset_size = sys.getsizeof(netcdf_io.dataset)
+        inmemory_size = sys.getsizeof(netcdf_io._in_memory_data)
 
-    assert dataset_size == dataset_size_after
-    assert inmemory_size == inmemory_size_after
+        var = "velocity"
+        assert len(netcdf_io._in_memory_data) == 0
+        netcdf_io._in_memory_data[var] = np.array(netcdf_io.dataset.variables[var])
+        assert len(netcdf_io._in_memory_data) == 1
+        _arr = netcdf_io._in_memory_data[var]
 
+        dataset_size_after = sys.getsizeof(netcdf_io.dataset)
+        inmemory_size_after = sys.getsizeof(netcdf_io._in_memory_data)
 
-@pytest.mark.xfail()
-def test_netcdf_io_intomemory_direct():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    dataset_size = sys.getsizeof(netcdf_io.dataset)
-    inmemory_size = sys.getsizeof(netcdf_io._in_memory_data)
+        assert dataset_size == dataset_size_after
+        assert inmemory_size < inmemory_size_after
+        assert sys.getsizeof(_arr) > 1000
 
-    var = "velocity"
-    assert len(netcdf_io._in_memory_data) == 0
-    netcdf_io._in_memory_data[var] = np.array(netcdf_io.dataset.variables[var])
-    assert len(netcdf_io._in_memory_data) == 1
-    _arr = netcdf_io._in_memory_data[var]
+    @pytest.mark.xfail()
+    def test_netcdf_io_intomemory_read(self):
+        netcdf_io = NetCDFIO(golf_path, "netcdf")
+        dataset_size = sys.getsizeof(netcdf_io.dataset)
+        inmemory_size = sys.getsizeof(netcdf_io._in_memory_data)
 
-    dataset_size_after = sys.getsizeof(netcdf_io.dataset)
-    inmemory_size_after = sys.getsizeof(netcdf_io._in_memory_data)
+        var = "velocity"
+        assert len(netcdf_io._in_memory_data) == 0
+        netcdf_io.read(var)
+        assert len(netcdf_io._in_memory_data) == 1
+        _arr = netcdf_io._in_memory_data[var]
 
-    assert dataset_size == dataset_size_after
-    assert inmemory_size < inmemory_size_after
-    assert sys.getsizeof(_arr) > 1000
+        assert isinstance(_arr, xr.core.dataarray.DataArray)
 
+        dataset_size_after = sys.getsizeof(netcdf_io.dataset)
+        inmemory_size_after = sys.getsizeof(netcdf_io._in_memory_data)
 
-@pytest.mark.xfail()
-def test_netcdf_io_intomemory_read():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    dataset_size = sys.getsizeof(netcdf_io.dataset)
-    inmemory_size = sys.getsizeof(netcdf_io._in_memory_data)
+        assert dataset_size == dataset_size_after
+        assert inmemory_size < inmemory_size_after
 
-    var = "velocity"
-    assert len(netcdf_io._in_memory_data) == 0
-    netcdf_io.read(var)
-    assert len(netcdf_io._in_memory_data) == 1
-    _arr = netcdf_io._in_memory_data[var]
+    def test_hdf5_io_init_without_engine(self):
+        netcdf_io = NetCDFIO(hdf_path)
+        assert netcdf_io.io_type == "file"
+        assert netcdf_io._engine == "h5netcdf"
+        assert len(netcdf_io._in_memory_data) == 0
 
-    assert isinstance(_arr, xr.core.dataarray.DataArray)
+    def test_hdf5_io_init_with_engine(self):
+        netcdf_io = NetCDFIO(hdf_path, engine="h5netcdf")
+        assert netcdf_io.io_type == "file"
+        assert netcdf_io._engine == "h5netcdf"
+        assert len(netcdf_io._in_memory_data) == 0
 
-    dataset_size_after = sys.getsizeof(netcdf_io.dataset)
-    inmemory_size_after = sys.getsizeof(netcdf_io._in_memory_data)
+    def test_hdf5_io_keys(self):
+        hdf5_io = NetCDFIO(hdf_path)
+        assert len(hdf5_io.keys) == 7
 
-    assert dataset_size == dataset_size_after
-    assert inmemory_size < inmemory_size_after
+    def test_nofile(self):
+        with pytest.raises(FileNotFoundError):
+            NetCDFIO("badpath")
 
+    def test_empty_file(self, empty_netcdf_file):
+        assert empty_netcdf_file.is_file()
+        with pytest.raises(NotImplementedError):
+            NetCDFIO(empty_netcdf_file)
 
-def test_hdf5_io_init():
-    with pytest.warns(UserWarning, match=r"No associated .*"):
-        netcdf_io = NetCDFIO(hdf_path, "hdf5")
-    assert netcdf_io.io_type == "hdf5"
-    assert len(netcdf_io._in_memory_data) == 0
+    def test_invalid_file(self, empty_txt_file):
+        assert empty_txt_file.is_file()
+        with pytest.raises(TypeError):
+            NetCDFIO(empty_txt_file)
 
+    def test_readvar_intomemory(self):
+        netcdf_io = NetCDFIO(golf_path, auxdata_path="meta")
+        assert netcdf_io._in_memory_data == {}
 
-def test_hdf5_io_keys():
-    with pytest.warns(UserWarning, match=r"No associated .*"):
-        hdf5_io = NetCDFIO(hdf_path, "hdf5")
-    assert len(hdf5_io.keys) == 7
+        netcdf_io.read("eta")
+        assert ("eta" in netcdf_io._in_memory_data) is True
 
+    def test_readvar_intomemory_error(self):
+        netcdf_io = NetCDFIO(golf_path)
+        assert netcdf_io._in_memory_data == {}
 
-def test_nofile():
-    with pytest.raises(FileNotFoundError):
-        NetCDFIO("badpath", "netcdf")
+        with pytest.raises(KeyError):
+            netcdf_io.read("nonexistant")
 
-
-def test_empty_file(empty_netcdf_file):
-    assert empty_netcdf_file.is_file()
-    with pytest.raises(NotImplementedError):
-        NetCDFIO(empty_netcdf_file, "netcdf")
-
-
-def test_invalid_file(empty_txt_file):
-    assert empty_txt_file.is_file()
-    with pytest.raises(TypeError):
-        NetCDFIO(empty_txt_file, "netcdf")
-
-
-def test_readvar_intomemory():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    assert netcdf_io._in_memory_data == {}
-
-    netcdf_io.read("eta")
-    assert ("eta" in netcdf_io._in_memory_data) is True
-
-
-def test_readvar_intomemory_error():
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    assert netcdf_io._in_memory_data == {}
-
-    with pytest.raises(KeyError):
-        netcdf_io.read("nonexistant")
-
-
-def test_netcdf_no_metadata():
-    # works fine, because there is no `connect` call in io init
-    netcdf_io = NetCDFIO(golf_path, "netcdf")
-    assert len(netcdf_io._in_memory_data) == 0
+    def test_netcdf_no_metadata(self):
+        # works fine, because there is no `connect` call in io init
+        netcdf_io = NetCDFIO(golf_path)
+        assert len(netcdf_io._in_memory_data) == 0
 
 
 class TestDictionaryIO:


### PR DESCRIPTION
Rename `meta` to `aux` at the `Cube` and `IO` levels. Enable `auxdata` to be specified when instantiating a `DataCube` and this argument is passed to the `NetCDFIO` file handler to set up this subgroup as the `cube.aux` attribute. 

No warning is issued if nothing is passed and nothing is detected for auxdata.

Note: this PR does keep automatic detection of a few subgroup names for now, just for backwards compatibility and a smoother transition, but warns that this will be removed in the future. 

todo
- [ ] implement this auxdata argument for `DictionaryIO`
- [x] rename cubes `_read_meta_from_file` to something more intuitive
- [x] clean up IO layer with making it more clear what is private